### PR TITLE
Make StaticDataBuffer and its next() method open

### DIFF
--- a/Sources/Core/StaticDataBuffer.swift
+++ b/Sources/Core/StaticDataBuffer.swift
@@ -5,7 +5,7 @@
     It's intent is to be subclassed so the next 
     function can be overridden with further rules.
 */
-public class StaticDataBuffer {
+open class StaticDataBuffer {
     private var localBuffer: [Byte] = []
     private var buffer: AnyIterator<Byte>
 
@@ -16,7 +16,7 @@ public class StaticDataBuffer {
 
     // MARK: Next
 
-    public func next() throws -> Byte? {
+    open func next() throws -> Byte? {
         /*
             Local buffer is used to maintain last bytes 
             while still interacting w/ byte buffer.

--- a/Tests/CoreTests/BlackBoxTests.swift
+++ b/Tests/CoreTests/BlackBoxTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+import Core
+
+class BlackBoxTests: XCTestCase {
+    static var allTests = [
+        ("testStaticDataBufferSubclassing", testStaticDataBufferSubclassing)
+    ]
+
+    func testStaticDataBufferSubclassing() throws {
+        class MyStaticDataBuffer: StaticDataBuffer {
+            init(bytes: Bytes) {
+                super.init(bytes: bytes)
+            }
+
+            override func next() throws -> Byte? {
+                return nil
+            }
+        }
+
+        let buffer = MyStaticDataBuffer(bytes: "hello".bytes)
+        XCTAssertEqual(try buffer.next(), nil)
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,6 +5,7 @@ import XCTest
 
 XCTMain([
     testCase(ArrayTests.allTests),
+    testCase(BlackBoxTests.allTests),
     testCase(BoolTests.allTests),
     testCase(BytesTests.allTests),
     testCase(ExtractableTests.allTests),


### PR DESCRIPTION
Since the `StaticDataBuffer` class and its `next()` method are intended to be subclassed/overridden outside of this module, mark both as `open`.
