### PR TITLE
Added Base64-Byte to Byte decoding

### DIFF
--- a/Sources/Core/Byte/Bytes+Base64.swift
+++ b/Sources/Core/Byte/Bytes+Base64.swift
@@ -1,13 +1,15 @@
 import Foundation
 
 extension Sequence where Iterator.Element == Byte {
+    @available(*, deprecated: 1.1, message: "Use `Bytes.base64Encoded.string` instead.")
     public var base64String: String {
         let bytes = [Byte](self)
         let data = Data(bytes: bytes)
 
         return data.base64EncodedString()
     }
-
+    
+    @available(*, deprecated: 1.1, message: "Use `Bytes.base64Encoded` instead.")
     public var base64Data: Bytes {
         let bytes = [Byte](self)
         let data = Data(bytes: bytes)
@@ -18,6 +20,31 @@ extension Sequence where Iterator.Element == Byte {
         encodedData.copyBytes(to: &encodedBytes, count: encodedData.count)
 
         return encodedBytes
+    }
+    
+    public var base64Encoded: Bytes {
+        let bytes = [Byte](self)
+        let data = Data(bytes: bytes)
+        
+        let encodedData = data.base64EncodedData()
+        
+        var encodedBytes = Bytes(repeating: 0, count: encodedData.count)
+        encodedData.copyBytes(to: &encodedBytes, count: encodedData.count)
+        
+        return encodedBytes
+    }
+    
+    public var base64Decoded: Bytes {
+        let bytes = [Byte](self)
+        let dataBase64 = Data(bytes: bytes)
+        guard let dataDecoded = Data(base64Encoded: dataBase64) else {
+            return []
+        }
+        
+        var decodedBytes = Bytes(repeating: 0, count: dataDecoded.count)
+        dataDecoded.copyBytes(to: &decodedBytes, count: dataDecoded.count)
+        
+        return decodedBytes
     }
 }
 

--- a/Sources/Core/Byte/Bytes+Base64.swift
+++ b/Sources/Core/Byte/Bytes+Base64.swift
@@ -49,6 +49,7 @@ extension Sequence where Iterator.Element == Byte {
 }
 
 extension String {
+    @available(*, deprecated: 1.1, message: "Use `String.bytes.base64Decoded.string` instead.")
     public var base64DecodedString: String {
         guard let data = NSData(base64Encoded: self, options: []) else { return "" }
         var bytes = Bytes(repeating: 0, count: data.length)

--- a/Tests/CoreTests/ByteTests.swift
+++ b/Tests/CoreTests/ByteTests.swift
@@ -65,7 +65,7 @@ class ByteTests: XCTestCase {
     public func testBase64() {
         XCTAssertEqual("dmFwb3I=".base64DecodedString, "vapor")
         XCTAssertEqual("⚠️".base64DecodedString, "")
-        XCTAssertEqual("hello".bytes.base64String, "aGVsbG8=")
-        XCTAssertEqual("hello".bytes.base64Data, "aGVsbG8=".bytes)
+        XCTAssertEqual("hello".bytes.base64Encoded.string, "aGVsbG8=")
+        XCTAssertEqual("hello".bytes.base64Encoded, "aGVsbG8=".bytes)
     }
 }

--- a/Tests/CoreTests/ByteTests.swift
+++ b/Tests/CoreTests/ByteTests.swift
@@ -63,8 +63,8 @@ class ByteTests: XCTestCase {
     }
 
     public func testBase64() {
-        XCTAssertEqual("dmFwb3I=".base64DecodedString, "vapor")
-        XCTAssertEqual("⚠️".base64DecodedString, "")
+        XCTAssertEqual("dmFwb3I=".bytes.base64Decoded.string, "vapor")
+        XCTAssertEqual("⚠️".bytes.base64Decoded.string, "")
         XCTAssertEqual("hello".bytes.base64Encoded.string, "aGVsbG8=")
         XCTAssertEqual("hello".bytes.base64Encoded, "aGVsbG8=".bytes)
     }


### PR DESCRIPTION
I added the ability to take Base64 encoded `Bytes` and decode them into `Bytes`. I also spoke with @tannernelson about the interface and we agreed that `base64Data` should be renamed to `base64Encoded` and that we already have functions for taking `Bytes` to `String` so we should deprecate the duplicate function and encourage others to move to `Bytes.base64Encoded.string`.

As for the implementation of `base64Decoded`, I was trying to find a way that accomplished this with less copies, but couldn't find anything while poking at `Data` and `NSData`.