### PR TITLE
fix decoding error in JWT

### DIFF
--- a/Sources/Core/Byte/Bytes+Base64.swift
+++ b/Sources/Core/Byte/Bytes+Base64.swift
@@ -37,7 +37,7 @@ extension Sequence where Iterator.Element == Byte {
     public var base64Decoded: Bytes {
         let bytes = [Byte](self)
         let dataBase64 = Data(bytes: bytes)
-        guard let dataDecoded = Data(base64Encoded: dataBase64) else {
+        guard let dataDecoded = Data(base64Encoded: dataBase64, options: .ignoreUnknownCharacters) else {
             return []
         }
         


### PR DESCRIPTION
This (finally!!! 🚀) fixes an issue preventing _some_ JWT tokens from failing to parse.