### PR TITLE
Add ISO8601 Date extension.

### DIFF
--- a/Sources/Core/ISO8601.swift
+++ b/Sources/Core/ISO8601.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+// Modified from http://stackoverflow.com/a/28016692/239380
+
+public struct ISO8601 {
+    public static let shared = ISO8601()
+    public let formatter: DateFormatter
+
+    public init() {
+        formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+    }
+}
+
+extension Date {
+    public var iso8601: String {
+        return ISO8601.shared.formatter.string(from: self)
+    }
+
+    public init?(iso8601: String) {
+        guard let date = ISO8601.shared.formatter.date(from: iso8601) else {
+            return nil
+        }
+        
+        self = date
+    }
+}

--- a/Tests/CoreTests/ISO8601Tests.swift
+++ b/Tests/CoreTests/ISO8601Tests.swift
@@ -5,7 +5,8 @@ import XCTest
 class ISO8601Tests: XCTestCase {
 
     static var allTests = [
-        ("testBasic", testBasic)
+        ("testBasic", testBasic),
+        ("testFail", testFail)
     ]
 
     func testBasic() {

--- a/Tests/CoreTests/ISO8601Tests.swift
+++ b/Tests/CoreTests/ISO8601Tests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import XCTest
+@testable import Core
+
+class ISO8601Tests: XCTestCase {
+
+    static var allTests = [
+        ("testBasic", testBasic)
+    ]
+
+    func testBasic() {
+        let date = Date(iso8601: "2016-06-18T05:18:27.935Z")
+        XCTAssertEqual(date?.iso8601, "2016-06-18T05:18:27.935Z")
+    }
+
+    func testFail() {
+        let date = Date(iso8601: "Ferret")
+        XCTAssertNil(date)
+    }
+}

--- a/Tests/CoreTests/RFC1123Tests.swift
+++ b/Tests/CoreTests/RFC1123Tests.swift
@@ -5,7 +5,8 @@ import XCTest
 class RFC1123Tests: XCTestCase {
 
     static var allTests = [
-        ("testBasic", testBasic)
+        ("testBasic", testBasic),
+        ("testFail", testFail)
     ]
 
     func testBasic() {


### PR DESCRIPTION
I needed more precision for dates on my models saved in the database, so thought it would be best to use ISO 8601 and thought it would be helpful to have in core.

There's also `ISO8601DateFormatter` introduced in iOS 10, but I'm not sure if this is available?