### PR TITLE
removing unpredictable string array function

### DIFF
--- a/Sources/Core/String+Polymorphic.swift
+++ b/Sources/Core/String+Polymorphic.swift
@@ -46,23 +46,25 @@ extension String {
 
     /// Attempts to convert the `String` to a `String`.
     /// This always works.
-    public var string: String? {
+    public var string: String {
         return self
     }
 
+    /// Converts the string to a UTF8 array of bytes.
+    public var bytes: [UInt8] {
+        return [UInt8](self.utf8)
+    }
+}
+
+extension String {
     /// Attempts to convert the `String` to an `Array`.
     /// Comma separated items will be split into
     /// multiple entries.
-    public var array: [String]? {
+    public func commaSeparatedArray() -> [String] {
         return characters
             .split(separator: ",")
             .map { String($0) }
             .map { $0.trimmedWhitespace() }
-    }
-
-    /// Converts the string to a UTF8 array of bytes.
-    public var bytes: [UInt8]? {
-        return [UInt8](self.utf8)
     }
 }
 

--- a/Tests/CoreTests/PolymorphicTests.swift
+++ b/Tests/CoreTests/PolymorphicTests.swift
@@ -28,7 +28,7 @@ class PolymorphicTests: XCTestCase {
 
     func testArray() {
         let list = "oranges, apples , bananas, grapes"
-        let fruits = list.array?.flatMap { $0.string } ?? []
+        let fruits = list.commaSeparatedArray()
         XCTAssert(fruits == ["oranges", "apples", "bananas", "grapes"])
     }
 


### PR DESCRIPTION
This has been creating unpredictable results and isn't really used anywhere. Users will now need to opt into the special comma separated behavior.