### PR TITLE
Use POSIX getcwd() function to get the real working directory

### DIFF
--- a/Tests/CoreTests/UtilityTests.swift
+++ b/Tests/CoreTests/UtilityTests.swift
@@ -39,10 +39,7 @@ class UtilityTests: XCTestCase {
     }
 
     func testWorkDir() {
-        let file = #file
-
         let workDir = workingDirectory()
-        XCTAssert(file.hasPrefix(workDir))
-        XCTAssertNotEqual(workDir, file)
+        XCTAssertNotEqual(workDir, "")
     }
 }


### PR DESCRIPTION
The previous implementation tried to parse the path of the source file, which works in select situations – e.g. if you "deploy" an app by copying sources somewhere, building the app, and running from the same folder till the end of time –, but fortunately we can do better.

The getcwd() function from POSIX returns the _actual_ working directory, the directory where the executable was started from. If for any reason the call fails, the previous behavior is used as a fallback.

Merging this will allow apps to run on Heroku without messing with the `--workDir` argument; other apps (that probably used the previously described strategy) are not affected.

The only sacrifice is the working directory test, as that tested the previous (not by definition correct) behavior.

(BTW, other Swift packages seem to use this function just fine, including SPM itself.)