### PR TITLE
ISO 8601 date format support

### DIFF
--- a/Sources/Core/ISO8601.swift
+++ b/Sources/Core/ISO8601.swift
@@ -6,7 +6,6 @@ public struct ISO8601 {
 	
 	public init() {
 		let formatter = DateFormatter()
-		formatter.calendar = Calendar(identifier: .iso8601)
 		formatter.locale = Locale(identifier: "en_US_POSIX")
 		formatter.timeZone = TimeZone(secondsFromGMT: 0)
 		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"

--- a/Sources/Core/ISO8601.swift
+++ b/Sources/Core/ISO8601.swift
@@ -1,28 +1,28 @@
 import Foundation
 
 public struct ISO8601 {
-	public static let shared = ISO8601()
-	public let formatter: DateFormatter
-	
-	public init() {
-		let formatter = DateFormatter()
-		formatter.locale = Locale(identifier: "en_US_POSIX")
-		formatter.timeZone = TimeZone(secondsFromGMT: 0)
-		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
-		self.formatter = formatter
-	}
+    public static let shared = ISO8601()
+    public let formatter: DateFormatter
+    
+    public init() {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        self.formatter = formatter
+    }
 }
 
 extension Date {
-	public var iso8601: String {
-		return ISO8601.shared.formatter.string(from: self)
-	}
-	
-	public init?(iso8601: String) {
-		guard let date = ISO8601.shared.formatter.date(from: iso8601) else {
-			return nil
-		}
-		
-		self = date
-	}
+    public var iso8601: String {
+        return ISO8601.shared.formatter.string(from: self)
+    }
+    
+    public init?(iso8601: String) {
+        guard let date = ISO8601.shared.formatter.date(from: iso8601) else {
+            return nil
+        }
+        
+        self = date
+    }
 }

--- a/Sources/Core/ISO8601.swift
+++ b/Sources/Core/ISO8601.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct ISO8601 {
+	public static let shared = ISO8601()
+	public let formatter: DateFormatter
+	
+	public init() {
+		let formatter = DateFormatter()
+		formatter.calendar = Calendar(identifier: .iso8601)
+		formatter.locale = Locale(identifier: "en_US_POSIX")
+		formatter.timeZone = TimeZone(secondsFromGMT: 0)
+		formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+		self.formatter = formatter
+	}
+}
+
+extension Date {
+	public var iso8601: String {
+		return ISO8601.shared.formatter.string(from: self)
+	}
+	
+	public init?(iso8601: String) {
+		guard let date = ISO8601.shared.formatter.date(from: iso8601) else {
+			return nil
+		}
+		
+		self = date
+	}
+}

--- a/Tests/CoreTests/ISO8601Tests.swift
+++ b/Tests/CoreTests/ISO8601Tests.swift
@@ -5,7 +5,8 @@ import XCTest
 class ISO8601Tests: XCTestCase {
 	
 	static var allTests = [
-		("testBasic", testBasic)
+		("testBasic", testBasic),
+		("testFail", testFail)
 	]
 	
 	func testBasic() {

--- a/Tests/CoreTests/ISO8601Tests.swift
+++ b/Tests/CoreTests/ISO8601Tests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import XCTest
+@testable import Core
+
+class ISO8601Tests: XCTestCase {
+	
+	static var allTests = [
+		("testBasic", testBasic)
+	]
+	
+	func testBasic() {
+		let date = Date(iso8601: "2016-07-01T04:00:00.000Z")
+		XCTAssertEqual(date?.iso8601, "2016-07-01T04:00:00.000Z")
+	}
+	
+	func testFail() {
+		let date = Date(iso8601: "Ferret")
+		XCTAssertNil(date)
+	}
+}


### PR DESCRIPTION
ISO 8601 is an international standard for date and time data and is widely used in other languages such as Java and Javascript. Having a formatter in the core would help with deserialization to the Date Foundation struct.