### PR TITLE
Removed use of deprecated String.characters property

### DIFF
--- a/Sources/Core/String+Polymorphic.swift
+++ b/Sources/Core/String+Polymorphic.swift
@@ -61,7 +61,7 @@ extension String {
     /// Comma separated items will be split into
     /// multiple entries.
     public func commaSeparatedArray() -> [String] {
-        return characters
+        return self
             .split(separator: ",")
             .map { String($0) }
             .map { $0.trimmedWhitespace() }
@@ -70,7 +70,7 @@ extension String {
 
 extension String {
     fileprivate func trimmedWhitespace() -> String {
-        var characters = self.characters
+        var characters = self
 
         while characters.first?.isWhitespace == true {
             characters.removeFirst()

--- a/Tests/CoreTests/ArrayTests.swift
+++ b/Tests/CoreTests/ArrayTests.swift
@@ -33,17 +33,17 @@ class ArrayTests: XCTestCase {
     }
 
     func testTrim() {
-        let result = Array("==hello==".characters).trimmed(["="])
+        let result = Array("==hello==").trimmed(["="])
         XCTAssertEqual(String(result), "hello")
     }
 
     func testTrimEmpty() {
-        let result = Array("".characters).trimmed([])
+        let result = Array("").trimmed([])
         XCTAssertEqual(String(result), "")
     }
 
     func testTrimAll() {
-        let result = Array("~~".characters).trimmed(["~"])
+        let result = Array("~~").trimmed(["~"])
         XCTAssertEqual(String(result), "")
     }
 }


### PR DESCRIPTION
Breaks Swift 3 compatibility; should not be merged until Vapor is bumped to 3.0.0.

See also: https://github.com/vapor/console/pull/47