### PR TITLE
Nice error message for enum keypath handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,5 +19,6 @@ let package = Package(
         .target(name: "COperatingSystem"),
         .target(name: "Debugging"),
         .testTarget(name: "DebuggingTests", dependencies: ["Debugging"]),
+        .testTarget(name: "CodableKitTests", dependencies: ["CodableKit"])
     ]
 )

--- a/Sources/CodableKit/Key/CodingKeyCollector.swift
+++ b/Sources/CodableKit/Key/CodingKeyCollector.swift
@@ -188,7 +188,8 @@ fileprivate struct CodingKeyCollectorKeyedDecoder<K>: KeyedDecodingContainerProt
             return custom._keyStringFalse as! T
         } else {
             let decoder = CodingKeyCollector(codingPath: codingPath + [key], result: result)
-            return try T(from: decoder)
+            
+            return try withEnumHeuristic(atPath: decoder.codingPath) { try T(from: decoder) }
         }
     }
 }

--- a/Sources/CodableKit/Key/KeyStringDecoder.swift
+++ b/Sources/CodableKit/Key/KeyStringDecoder.swift
@@ -61,50 +61,34 @@ private func isTruthy(_ any: Any?) -> Bool {
 internal func withEnumHeuristic<T>(atPath codingPath: [CodingKey], work: () throws -> T) throws -> T {
     do {
         return try work()
-    } catch Swift.DecodingError.dataCorrupted(let context) where context.codingPath.count == codingPath.count {
+    } catch Swift.DecodingError.dataCorrupted(let context) where
+        context.codingPath.count == codingPath.count &&
+        //T.self is RawRepresentable &&      // RawRepresentable is an existential, this doesn't work
+        !(T.self is AnyKeyStringDecodable) &&
+       context.debugDescription.hasPrefix("Cannot initialize \(T.self) from invalid") &&
+       (context.debugDescription.hasSuffix("value 1") || context.debugDescription.hasSuffix("value 0"))
+    {
         // This heuristic is bad. It relies too much on the specific content of
         // an error message from inside the Swift stdlib. Find a better way to
         // detect this particular error case if at all possible.
 
-        if //T.self is RawRepresentable &&      // RawRepresentable is an existential, this doesn't work
-           !(T.self is AnyKeyStringDecodable) &&
-           context.debugDescription.hasPrefix("Cannot initialize \(T.self) from invalid") &&
-           (context.debugDescription.hasSuffix("value 1") || context.debugDescription.hasSuffix("value 0"))
-        {
-            // Is this too much information? Should we just give a docs link instead?
-            fatalError("""
-                
-                
-                It looks like you tried to derive a keypath for a RawRepresentable enum which
-                has a compiler-generated Codable conformance. This most often happens because
-                you tried to use an enum with Fluent's automatic schema generation.
-                
-                The type is:
-                \(T.self)
-                
-                If this type is not an enum, please let us know what you were actually doing
-                so we can improve the quirky hueristic that generates this error message!
-                
-                Deriving keypaths for enums automagically is not yet supported, pending the
-                completion, acceptance, implementation, and release of what at the time of
-                this writing was a draft swift-evolution proposal. This is not expected to
-                happen any time soon.
-                
-                https://github.com/jtbandes/swift-evolution/blob/case-enumerable/proposals/0000-derived-collection-of-enum-cases.md
-                
-                The recommended solution is to conform your enum to the KeyStringDecodable
-                protocol, implement keyStringTrue to return one enum case, and implement
-                keyStringFalse to return a different enum case. The actual values of the
-                cases don't matter, as long as Equatable will see them as different.
-                
-                There is no trivial solution for enums with only one case at this time. Sorry!
-                
-                
-                """
-            )
-        } else {
-            throw Swift.DecodingError.dataCorrupted(context)
-        }
+        fatalError("""
+            
+            
+            It looks like you tried to get a keypath for \(T.self), which seems to be an
+            enum. Conform \(T.self) to the KeyStringDecodable protocol to make this work.
+            Here is some sample code to get you started:
+            
+            extension \(T.self): KeyStringDecodable {
+                public static var keyStringTrue: \(T.self) { return <#one enum case#> }
+                public static var keyStringFalse: \(T.self) { return <#another enum case#> }
+            }
+            
+            See https://docs.vapor.codes/3.0/fluent/models/ for more information.
+            
+            
+            """
+        )
     }
 }
 

--- a/Tests/CodableKitTests/KeyStringDecoderTests.swift
+++ b/Tests/CodableKitTests/KeyStringDecoderTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import Foundation
+@testable import CodableKit
+
+class KeyStringDecoderTests: XCTestCase {
+    static let allTests = [
+        ("testKeyStringDecodableEnum", testKeyStringDecodableEnum),
+    ]
+    
+    func testKeyStringDecodableEnum() throws {
+        let expectedPath: [CodingKey] = [CleanWrapperStructure.desiredCodingKey, CleanNestedWrapperStructure.desiredCodingKey]
+        let actualPath = CleanWrapperStructure.codingPath(forKey: \CleanWrapperStructure.wrapping.areYouOfferingMeAJob)
+        
+        XCTAssertEqual(actualPath.count, expectedPath.count)
+        actualPath.enumerated().forEach {
+            XCTAssertEqual($0.element.stringValue, expectedPath[$0.offset].stringValue)
+        }
+        
+        // Uncomment to test that Swift crashes as expected.
+        // Commented by default because XCTest has no means to trap a fatalError()
+        // This is in turn because fatalError() fires an undefined opcode, which
+        // it's not really possible to safely trap.
+        //let _ = SorryMessWrapperStructure.codingPath(forKey: \SorryMessWrapperStructure.wrapping.youHaveAlwaysBeenHere)
+    }
+}
+
+// - MARK: Success fixtures
+
+enum GoodKeypathedEnum: String, Codable, KeyStringDecodable {
+    case hello, goodbye, allAlongTheWatchtower
+    
+    static var keyStringTrue: GoodKeypathedEnum { return .hello }
+    static var keyStringFalse: GoodKeypathedEnum { return .goodbye }
+}
+
+struct CleanNestedWrapperStructure: Codable {
+
+    static var desiredCodingKey: CodingKey { return CleanNestedWrapperStructure.CodingKeys.areYouOfferingMeAJob }
+
+    let areYouOfferingMeAJob: GoodKeypathedEnum
+    
+}
+
+struct CleanWrapperStructure: Codable {
+    
+    static var desiredCodingKey: CodingKey { return CleanWrapperStructure.CodingKeys.wrapping }
+
+    let wrapping: CleanNestedWrapperStructure
+
+}
+
+// - MARK: Failure fixtures
+
+enum BadKeypathedEnum: String, Codable {
+    case olleh, eybdoog, onlyChildrenCanKnowMyName
+}
+
+struct SorryMessNestedWrapperStructure: Codable {
+
+    static var desiredCodingKey: CodingKey { return SorryMessNestedWrapperStructure.CodingKeys.youHaveAlwaysBeenHere }
+
+    let youHaveAlwaysBeenHere: BadKeypathedEnum
+
+}
+
+struct SorryMessWrapperStructure: Codable {
+
+    static var desiredCodingKey: CodingKey { return SorryMessWrapperStructure.CodingKeys.wrapping }
+
+    let wrapping: SorryMessNestedWrapperStructure
+    
+}
+

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,11 +2,14 @@
 
 import XCTest
 @testable import DebuggingTests
+@testable import CodableKitTests
 
 XCTMain([
     testCase(FooErrorTests.allTests),
     testCase(GeneralTests.allTests),
     testCase(TraceableTests.allTests),
+    
+    testCase(KeyStringDecoderTests.allTests),
 ])
 
 #endif


### PR DESCRIPTION
I'll give a cookie to the first person who correctly identifies all four of the silly nerdy sci-fi TV references in the test fixtures 😈 