### PR TITLE
properties depth + cc fixes

### DIFF
--- a/Sources/CodableKit/Key/KeyStringDecodable.swift
+++ b/Sources/CodableKit/Key/KeyStringDecodable.swift
@@ -77,24 +77,47 @@ extension Date: KeyStringDecodable {
     public static var keyStringFalse: Date { return Date(timeIntervalSince1970: 0) }
 }
 
-extension Array: KeyStringDecodable, AnyKeyStringDecodable where Element: KeyStringDecodable {
-    public static func keyStringIsTrue(_ item: Array<Element>) -> Bool { return Element.keyStringIsTrue(item[0]) }
-    public static var keyStringTrue: Array<Element> { return [Element.keyStringTrue] }
-    public static var keyStringFalse: Array<Element> { return [Element.keyStringFalse] }
+extension Array: KeyStringDecodable, AnyKeyStringDecodable {
+    public static func keyStringIsTrue(_ item: Array<Element>) -> Bool {
+        return requireKeyStringDecodable(Element.self)._keyStringIsTrue(item[0])
+    }
+    public static var keyStringTrue: Array<Element> {
+        return [requireKeyStringDecodable(Element.self)._keyStringTrue as! Element]
+    }
+    public static var keyStringFalse: Array<Element> {
+        return [requireKeyStringDecodable(Element.self)._keyStringFalse as! Element]
+    }
 }
 
-extension Dictionary: KeyStringDecodable, AnyKeyStringDecodable where Value: KeyStringDecodable, Key == String {
-    public static func keyStringIsTrue(_ item: Dictionary<String, Value>) -> Bool { return Value.keyStringIsTrue(item[""]!) }
-    public static var keyStringTrue: Dictionary<Key, Value> { return ["": Value.keyStringTrue] }
-    public static var keyStringFalse: Dictionary<Key, Value> { return ["": Value.keyStringFalse] }
+extension Dictionary: KeyStringDecodable, AnyKeyStringDecodable {
+    public static func keyStringIsTrue(_ item: Dictionary<Key, Value>) -> Bool {
+        return requireKeyStringDecodable(Value.self)._keyStringIsTrue(item["" as! Key]!)
+    }
+    public static var keyStringTrue: Dictionary<Key, Value> {
+        return ["" as! Key: requireKeyStringDecodable(Value.self)._keyStringTrue as! Value]
+    }
+    public static var keyStringFalse: Dictionary<Key, Value> {
+        return ["" as! Key: requireKeyStringDecodable(Value.self)._keyStringFalse as! Value]
+    }
 }
-extension Optional: KeyStringDecodable, AnyKeyStringDecodable where Wrapped: KeyStringDecodable {
+extension Optional: KeyStringDecodable, AnyKeyStringDecodable {
     public static func keyStringIsTrue(_ item: Optional<Wrapped>) -> Bool {
         guard let item = item else {
             return false
         }
-        return Wrapped.keyStringIsTrue(item)
+        return requireKeyStringDecodable(Wrapped.self)._keyStringIsTrue(item)
     }
-    public static var keyStringTrue: Optional<Wrapped> { return Wrapped.keyStringTrue }
-    public static var keyStringFalse: Optional<Wrapped> { return Wrapped.keyStringFalse }
+    public static var keyStringTrue: Optional<Wrapped> {
+        return requireKeyStringDecodable(Wrapped.self)._keyStringTrue as? Wrapped
+    }
+    public static var keyStringFalse: Optional<Wrapped> {
+        return requireKeyStringDecodable(Wrapped.self)._keyStringFalse as? Wrapped
+    }
+}
+
+func requireKeyStringDecodable<T>(_ type: T.Type) -> AnyKeyStringDecodable.Type {
+    guard let type = T.self as? AnyKeyStringDecodable.Type else {
+        fatalError("\(T.self) does not conform to `KeyStringDecodable`.")
+    }
+    return type
 }

--- a/Sources/CodableKit/ZeroDecoder.swift
+++ b/Sources/CodableKit/ZeroDecoder.swift
@@ -1,0 +1,232 @@
+final class ZeroDecoder: Decoder {
+    var codingPath: [CodingKey]
+    var userInfo: [CodingUserInfoKey : Any]
+
+    init() {
+        self.codingPath = []
+        self.userInfo = [:]
+    }
+
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+        return KeyedDecodingContainer(ZeroKeyedDecoder<Key>())
+    }
+
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        return ZeroUnkeyedDecoder()
+    }
+
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        return ZeroSingleValueDecoder()
+    }
+}
+
+final class ZeroUnkeyedDecoder: UnkeyedDecodingContainer {
+    var codingPath: [CodingKey]
+    var count: Int?
+    var isAtEnd: Bool
+    var currentIndex: Int
+    init() {
+        self.codingPath = []
+        self.count = nil
+        self.isAtEnd = true
+        self.currentIndex = 0
+    }
+    func decodeNil() throws -> Bool { return false }
+    func decode(_ type: Bool.Type) throws -> Bool {
+        return false
+    }
+    func decode(_ type: String.Type) throws -> String {
+        return "0"
+    }
+    func decode(_ type: Double.Type) throws -> Double {
+        return 0
+    }
+    func decode(_ type: Float.Type) throws -> Float {
+        return 0
+    }
+    func decode(_ type: Int.Type) throws -> Int {
+        return 0
+    }
+    func decode(_ type: Int8.Type) throws -> Int8 {
+        return 0
+    }
+    func decode(_ type: Int16.Type) throws -> Int16 {
+        return 0
+    }
+    func decode(_ type: Int32.Type) throws -> Int32 {
+        return 0
+    }
+    func decode(_ type: Int64.Type) throws -> Int64 {
+        return 0
+    }
+    func decode(_ type: UInt.Type) throws -> UInt {
+        return 0
+    }
+    func decode(_ type: UInt8.Type) throws -> UInt8 {
+        return 0
+    }
+    func decode(_ type: UInt16.Type) throws -> UInt16 {
+        return 0
+    }
+    func decode(_ type: UInt32.Type) throws -> UInt32 {
+        return 0
+    }
+    func decode(_ type: UInt64.Type) throws -> UInt64 {
+        return 0
+    }
+    func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        if let type = T.self as? AnyKeyStringDecodable.Type {
+            return type._keyStringFalse as! T
+        } else {
+            return try T(from: ZeroDecoder())
+        }
+    }
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        return KeyedDecodingContainer(ZeroKeyedDecoder<NestedKey>())
+    }
+    func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        return ZeroUnkeyedDecoder()
+    }
+    func superDecoder() throws -> Decoder {
+        return ZeroDecoder()
+    }
+}
+
+final class ZeroKeyedDecoder<K>: KeyedDecodingContainerProtocol where K: CodingKey {
+    typealias Key = K
+    var codingPath: [CodingKey]
+    var allKeys: [K]
+    init() {
+        self.codingPath = []
+        self.allKeys = []
+    }
+    func contains(_ key: K) -> Bool {
+        return false
+    }
+    func decodeNil(forKey key: K) throws -> Bool {
+        return false
+    }
+    func decode(_ type: Bool.Type, forKey key: K) throws -> Bool {
+        return false
+    }
+    func decode(_ type: String.Type, forKey key: K) throws -> String {
+        return "0"
+    }
+    func decode(_ type: Double.Type, forKey key: K) throws -> Double {
+        return 0
+    }
+    func decode(_ type: Float.Type, forKey key: K) throws -> Float {
+        return 0
+    }
+    func decode(_ type: Int.Type, forKey key: K) throws -> Int {
+        return 0
+    }
+    func decode(_ type: Int8.Type, forKey key: K) throws -> Int8 {
+        return 0
+    }
+    func decode(_ type: Int16.Type, forKey key: K) throws -> Int16 {
+        return 0
+    }
+    func decode(_ type: Int32.Type, forKey key: K) throws -> Int32 {
+        return 0
+    }
+    func decode(_ type: Int64.Type, forKey key: K) throws -> Int64 {
+        return 0
+    }
+    func decode(_ type: UInt.Type, forKey key: K) throws -> UInt {
+        return 0
+    }
+    func decode(_ type: UInt8.Type, forKey key: K) throws -> UInt8 {
+        return 0
+    }
+    func decode(_ type: UInt16.Type, forKey key: K) throws -> UInt16 {
+        return 0
+    }
+    func decode(_ type: UInt32.Type, forKey key: K) throws -> UInt32 {
+        return 0
+    }
+    func decode(_ type: UInt64.Type, forKey key: K) throws -> UInt64 {
+        return 0
+    }
+    func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T : Decodable {
+        if let type = T.self as? AnyKeyStringDecodable.Type {
+            return type._keyStringFalse as! T
+        } else {
+            return try T(from: ZeroDecoder())
+        }
+    }
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        return KeyedDecodingContainer(ZeroKeyedDecoder<NestedKey>())
+    }
+    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
+        return ZeroUnkeyedDecoder()
+    }
+    func superDecoder() throws -> Decoder {
+        return ZeroDecoder()
+    }
+    func superDecoder(forKey key: K) throws -> Decoder {
+        return ZeroDecoder()
+    }
+}
+
+final class ZeroSingleValueDecoder: SingleValueDecodingContainer {
+    var codingPath: [CodingKey]
+
+    init() {
+        self.codingPath = []
+    }
+
+    func decodeNil() -> Bool {
+        return false
+    }
+
+    func decode(_ type: Bool.Type) throws -> Bool {
+        return false
+    }
+    func decode(_ type: String.Type) throws -> String {
+        return "0"
+    }
+    func decode(_ type: Double.Type) throws -> Double {
+        return 0
+    }
+    func decode(_ type: Float.Type) throws -> Float {
+        return 0
+    }
+    func decode(_ type: Int.Type) throws -> Int {
+        return 0
+    }
+    func decode(_ type: Int8.Type) throws -> Int8 {
+        return 0
+    }
+    func decode(_ type: Int16.Type) throws -> Int16 {
+        return 0
+    }
+    func decode(_ type: Int32.Type) throws -> Int32 {
+        return 0
+    }
+    func decode(_ type: Int64.Type) throws -> Int64 {
+        return 0
+    }
+    func decode(_ type: UInt.Type) throws -> UInt {
+        return 0
+    }
+    func decode(_ type: UInt8.Type) throws -> UInt8 {
+        return 0
+    }
+    func decode(_ type: UInt16.Type) throws -> UInt16 {
+        return 0
+    }
+    func decode(_ type: UInt32.Type) throws -> UInt32 {
+        return 0
+    }
+    func decode(_ type: UInt64.Type) throws -> UInt64 {
+        return 0
+    }
+    func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        if let type = T.self as? AnyKeyStringDecodable.Type {
+            return type._keyStringFalse as! T
+        } else {
+            return try T(from: ZeroDecoder())
+        }
+    }
+}

--- a/Tests/CodableKitTests/KeyStringDecoderTests.swift
+++ b/Tests/CodableKitTests/KeyStringDecoderTests.swift
@@ -89,7 +89,22 @@ class KeyStringDecoderTests: XCTestCase {
         }
 
         let properties = User.properties()
-        XCTAssertEqual(properties.description, "[int: Int, oint: Int?, int8: Int8, oint8: Int8?, int16: Int16, oint16: Int16?, int32: Int32, oint32: Int32?, int64: Int64, oint64: Int64?, uint: UInt, uoint: UInt?, uint8: UInt8, uoint8: UInt8?, uint16: UInt16, uoint16: UInt16?, uint32: UInt32, uoint32: UInt32?, uint64: UInt64, uoint64: UInt64?, uuid: UUID, ouuid: UUID?, date: Date, odate: Date?, float: Float, ofloat: Float?, double: Double, odouble: Double?, string: String, ostring: String?, bool: Bool, obool: Bool?]")
+        XCTAssertEqual(properties.description, "[int: Int, oint: Int?, int8: Int8, oint8: Int8?, int16: Int16, oint16: Int16?, int32: Int32, oint32: Int32?, int64: Int64, oint64: Int64?, uint: UInt, uoint: UInt?, uint8: UInt8, uoint8: UInt8?, uint16: UInt16, uoint16: UInt16?, uint32: UInt32, uoint32: UInt32?, uint64: UInt64, uoint64: UInt64?, uuid: UUID, ouuid: UUID?, date: Date, odate: Date?, float: Float, ofloat: Float?, double: Double, odouble: Double?, string: String, ostring: String?, bool: Bool, obool: Bool?, array: Array<String>, oarray: Array<String>?, dict: Dictionary<String, String>, odict: Dictionary<String, String>?]")
+    }
+
+    func testPropertyDepth() {
+        struct Pet: Decodable {
+            var nickname: String
+            var favoriteTreat: String
+        }
+        struct User: Decodable {
+            var pet: Pet
+            var name: String
+            var age: Int
+        }
+
+        XCTAssertEqual(User.properties(depth: 1).description, "[pet: Pet #1, name: String, age: Int]")
+        XCTAssertEqual(User.properties(depth: 2).description, "[pet.nickname: String, pet.favoriteTreat: String, name: String, age: Int]")
     }
 
     static let allTests = [

--- a/Tests/CodableKitTests/KeyStringDecoderTests.swift
+++ b/Tests/CodableKitTests/KeyStringDecoderTests.swift
@@ -110,5 +110,7 @@ class KeyStringDecoderTests: XCTestCase {
     static let allTests = [
         ("testSimpleStruct", testSimpleStruct),
         ("testNestedStruct", testNestedStruct),
+        ("testProperties", testProperties),
+        ("testPropertyDepth", testPropertyDepth),
     ]
 }


### PR DESCRIPTION
- [x] fixes a bug where `Decodable.properties()` would not respect the `depth: Int` parameter.
- [x] removes some conditional conformance code where ability to dynamically cast is required
- [x] adds an internal `ZeroDecoder` that initializes decodable models w/ "0"/false values.