### PR TITLE
Improve the API of Base64

### DIFF
--- a/Sources/Bits/Base64.swift
+++ b/Sources/Bits/Base64.swift
@@ -9,14 +9,12 @@ public final class Base64 {
     public static let shared = Base64.regular
 
     /// Standard Base64Encoder
-    public static var regular: Base64 {
-        return Base64()
-    }
+    public static let regular = Base64()
 
     // Base64URLEncoder
     // - note: uses hyphens and underscores
     //         in place of plus and forwardSlash
-    public static var url: Base64 {
+    public static let url: Base64 = {
         let encodeMap: Base64.ByteMap = { byte in
             switch byte {
             case 62:
@@ -44,7 +42,7 @@ public final class Base64 {
             encodeMap: encodeMap,
             decodeMap: decodeMap
         )
-    }
+    }()
 
     /// Maps binary format to base64 encoding
     static let encodingTable: [Byte: Byte] = [
@@ -115,7 +113,7 @@ public final class Base64 {
     }
 
     /// Encodes bytes into Base64 format
-    public func encode(data bytes: Data) throws -> Data {
+    public func encode(data bytes: Data) -> Data {
         if bytes.count == 0 {
             return bytes
         }
@@ -129,10 +127,11 @@ public final class Base64 {
         while offset < len {
             c1 = bytes[offset] & 0xff
             offset += 1
-            try result.append(encode((c1 >> 2) & 0x3f))
+			// These computations should never return a byte outside (0...63), so it is safe to forcibly try here.
+            try! result.append(encode((c1 >> 2) & 0x3f))
             c1 = (c1 & 0x03) << 4
             if offset >= len {
-                try result.append(encode(c1 & 0x3f))
+                try! result.append(encode(c1 & 0x3f))
                 if let padding = self.padding {
                     result.append(padding)
                     result.append(padding)
@@ -143,10 +142,10 @@ public final class Base64 {
             c2 = bytes[offset] & 0xff
             offset += 1
             c1 |= (c2 >> 4) & 0x0f
-            try result.append(encode(c1 & 0x3f))
+            try! result.append(encode(c1 & 0x3f))
             c1 = (c2 & 0x0f) << 2
             if offset >= len {
-                try result.append(encode(c1 & 0x3f))
+                try! result.append(encode(c1 & 0x3f))
                 if let padding = self.padding {
                     result.append(padding)
                 }
@@ -156,8 +155,8 @@ public final class Base64 {
             c2 = bytes[offset] & 0xff
             offset += 1
             c1 |= (c2 >> 6) & 0x03
-            try result.append(encode(c1 & 0x3f))
-            try result.append(encode(c2 & 0x3f))
+            try! result.append(encode(c1 & 0x3f))
+            try! result.append(encode(c2 & 0x3f))
         }
 
         return result
@@ -165,7 +164,8 @@ public final class Base64 {
 
     /// Decodes bytes into binary format
     public func decode(data s: Data) throws -> Data {
-        let maxolen = s.count
+        let ilen = s.count
+		let maxolen = (ilen * 3) / 4 + 1
 
         var off: Int = 0
         var olen: Int = 0
@@ -177,38 +177,59 @@ public final class Base64 {
         var c4: Byte
         var o: Byte
 
-        while off < s.count - 1 && olen < maxolen {
-            c1 = try decode(s[off])
+        while off < ilen && olen < maxolen {
+			let s1 = s[off]
+			if s1 == self.padding {
+				throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
+			}
+            c1 = try decode(s1)
             off += 1
-            c2 = try decode(s[off])
+			if off >= ilen {
+				throw BitsError(identifier: "base64Decode", reason: "Unexpected string end", source: .capture())
+			}
+			let s2 = s[off]
+			if s2 == self.padding {
+				throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
+			}
+            c2 = try decode(s2)
             off += 1
-            if c1 == Byte.max || c2 == Byte.max {
-                break
-            }
 
             o = c1 << 2
             o |= (c2 & 0x30) >> 4
             result[olen] = o
             olen += 1
-            if olen >= maxolen || off >= s.count {
+            if olen >= maxolen || off >= ilen {
                 break
             }
 
-            c3 = try decode(s[off])
+			let s3 = s[off]
+			if s3 == self.padding {
+				if ilen != off + 2 || s[off + 1] != self.padding {
+					throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
+				}
+				off = ilen
+				break
+			}
+            c3 = try decode(s3)
             off += 1
-            if c3 == Byte.max {
-                break
-            }
 
             o = (c2 & 0x0f) << 4
             o |= (c3 & 0x3c) >> 2
             result[olen] = o
             olen += 1
-            if olen >= maxolen || off >= s.count {
+            if olen >= maxolen || off >= ilen {
                 break
             }
 
-            c4 = try decode(s[off])
+			let s4 = s[off]
+			if s4 == self.padding {
+				if ilen != off + 1 {
+					throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
+				}
+				off = ilen
+				break
+			}
+            c4 = try decode(s4)
             off += 1
             if c4 == Byte.max {
                 break
@@ -218,6 +239,10 @@ public final class Base64 {
             result[olen] = o
             olen += 1
         }
+		
+		if off != ilen {
+			throw BitsError(identifier: "base64Decode", reason: "Unexpected string end", source: .capture())
+		}
 
         return Data(result[0..<olen])
     }
@@ -249,7 +274,9 @@ extension String {
 
 extension Data {
     /// Transforms Data into a Base64 encoded string.
-    public func base64Encoded(_ coder: Base64 = .regular, encoding: String.Encoding = .utf8) throws -> String? {
-        return try String(data: coder.encode(data: self), encoding: encoding)
+    public func base64Encoded(_ coder: Base64 = .regular) -> String {
+		// The result will always be a valid UTF8 string (unless you provided a terrible encoding table),
+		// so it is safe to forcibly unwrap here.
+        return String(data: coder.encode(data: self), encoding: .utf8)!
     }
 }

--- a/Sources/Bits/Base64.swift
+++ b/Sources/Bits/Base64.swift
@@ -127,11 +127,10 @@ public final class Base64 {
         while offset < len {
             c1 = bytes[offset] & 0xff
             offset += 1
-			// These computations should never return a byte outside (0...63), so it is safe to forcibly try here.
-            try! result.append(encode((c1 >> 2) & 0x3f))
+            result.append(encode((c1 >> 2) & 0x3f))
             c1 = (c1 & 0x03) << 4
             if offset >= len {
-                try! result.append(encode(c1 & 0x3f))
+                result.append(encode(c1 & 0x3f))
                 if let padding = self.padding {
                     result.append(padding)
                     result.append(padding)
@@ -142,10 +141,10 @@ public final class Base64 {
             c2 = bytes[offset] & 0xff
             offset += 1
             c1 |= (c2 >> 4) & 0x0f
-            try! result.append(encode(c1 & 0x3f))
+            result.append(encode(c1 & 0x3f))
             c1 = (c2 & 0x0f) << 2
             if offset >= len {
-                try! result.append(encode(c1 & 0x3f))
+                result.append(encode(c1 & 0x3f))
                 if let padding = self.padding {
                     result.append(padding)
                 }
@@ -155,8 +154,8 @@ public final class Base64 {
             c2 = bytes[offset] & 0xff
             offset += 1
             c1 |= (c2 >> 6) & 0x03
-            try! result.append(encode(c1 & 0x3f))
-            try! result.append(encode(c2 & 0x3f))
+            result.append(encode(c1 & 0x3f))
+            result.append(encode(c2 & 0x3f))
         }
 
         return result
@@ -165,7 +164,7 @@ public final class Base64 {
     /// Decodes bytes into binary format
     public func decode(data s: Data) throws -> Data {
         let ilen = s.count
-		let maxolen = (ilen * 3) / 4 + 1
+        let maxolen = (ilen * 3) / 4 + 1
 
         var off: Int = 0
         var olen: Int = 0
@@ -178,19 +177,19 @@ public final class Base64 {
         var o: Byte
 
         while off < ilen && olen < maxolen {
-			let s1 = s[off]
-			if s1 == self.padding {
-				throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
-			}
+            let s1 = s[off]
+            if s1 == self.padding {
+                throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
+            }
             c1 = try decode(s1)
             off += 1
-			if off >= ilen {
-				throw BitsError(identifier: "base64Decode", reason: "Unexpected string end", source: .capture())
-			}
-			let s2 = s[off]
-			if s2 == self.padding {
-				throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
-			}
+            if off >= ilen {
+                throw BitsError(identifier: "base64Decode", reason: "Unexpected string end", source: .capture())
+            }
+            let s2 = s[off]
+            if s2 == self.padding {
+                throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
+            }
             c2 = try decode(s2)
             off += 1
 
@@ -202,14 +201,14 @@ public final class Base64 {
                 break
             }
 
-			let s3 = s[off]
-			if s3 == self.padding {
-				if ilen != off + 2 || s[off + 1] != self.padding {
-					throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
-				}
-				off = ilen
-				break
-			}
+            let s3 = s[off]
+            if s3 == self.padding {
+                if ilen != off + 2 || s[off + 1] != self.padding {
+                    throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
+                }
+                off = ilen
+                break
+            }
             c3 = try decode(s3)
             off += 1
 
@@ -221,14 +220,14 @@ public final class Base64 {
                 break
             }
 
-			let s4 = s[off]
-			if s4 == self.padding {
-				if ilen != off + 1 {
-					throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
-				}
-				off = ilen
-				break
-			}
+            let s4 = s[off]
+            if s4 == self.padding {
+                if ilen != off + 1 {
+                    throw BitsError(identifier: "base64Decode", reason: "Unexpected padding character", source: .capture())
+                }
+                off = ilen
+                break
+            }
             c4 = try decode(s4)
             off += 1
             if c4 == Byte.max {
@@ -239,18 +238,18 @@ public final class Base64 {
             result[olen] = o
             olen += 1
         }
-		
-		if off != ilen {
-			throw BitsError(identifier: "base64Decode", reason: "Unexpected string end", source: .capture())
-		}
+        
+        if off != ilen {
+            throw BitsError(identifier: "base64Decode", reason: "Unexpected string end", source: .capture())
+        }
 
         return Data(result[0..<olen])
     }
 
     // MARK: Private
-    private func encode(_ x: Byte) throws -> Byte {
+    private func encode(_ x: Byte) -> Byte {
         guard let encoded = encodeMap?(x) ?? Base64.encodingTable[x] else {
-            throw BitsError(identifier: "base64Encode", reason: "Could not base64 encode byte: \(x)", source: .capture())
+            fatalError("Could not base64 encode byte: \(x). This should never happen!")
         }
         return encoded
     }
@@ -275,8 +274,9 @@ extension String {
 extension Data {
     /// Transforms Data into a Base64 encoded string.
     public func base64Encoded(_ coder: Base64 = .regular) -> String {
-		// The result will always be a valid UTF8 string (unless you provided a terrible encoding table),
-		// so it is safe to forcibly unwrap here.
-        return String(data: coder.encode(data: self), encoding: .utf8)!
+        guard let encoded = String(data: coder.encode(data: self), encoding: .utf8) else {
+            fatalError("Could not convert base64-encoded data to string. This should never happen - did you provide an invalid encoding table?")
+        }
+        return encoded
     }
 }

--- a/Tests/BitsTests/Base64Tests.swift
+++ b/Tests/BitsTests/Base64Tests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import Bits
+
+final class Base64Tests: XCTestCase {
+	private func checkEncodeDecode(coder: Base64, hasPadding: Bool = true) {
+		var rawData = Data()
+		for currentLength in 0...256 {
+			// Tests [], [0], [0, 1], etc., all the way up to [0, 1, ..., 255].
+			let encoded = rawData.base64Encoded(coder)
+			if hasPadding {
+				XCTAssertEqual(encoded.count, Int(ceil(Double(rawData.count) / 3) * 4))
+			} else {
+				XCTAssertEqual(encoded.count, Int(ceil(Double(rawData.count * 4) / 3)))
+			}
+			
+			if coder === Base64.regular {
+				// Compare with the results from Foundation's Base64 coder
+				XCTAssertEqual(encoded, rawData.base64EncodedString())
+				XCTAssertEqual(Data(base64Encoded: encoded)!, rawData)
+			}
+			XCTAssertEqual(try encoded.base64Decoded(coder), rawData)
+			if currentLength <= 255 {
+				rawData.append(UInt8(currentLength))
+			}
+		}
+	}
+	
+	func testEncodeDecodeRegular() {
+		checkEncodeDecode(coder: .regular)
+	}
+	
+	func testEncodeDecodeNoPadding() {
+		checkEncodeDecode(coder: Base64(padding: nil, encodeMap: nil, decodeMap: nil), hasPadding: false)
+	}
+	
+	func testEncodeDecodeURL() {
+		checkEncodeDecode(coder: .url, hasPadding: false)
+	}
+	
+	func testDecoderWithPaddingExpectsCorrectAmountOfPaddingOrNone1() {
+		var encoded = "AA=="
+		XCTAssertEqual(try encoded.base64Decoded(.regular), Data(bytes: [0]))
+		encoded.removeLast()
+		XCTAssertThrowsError(try encoded.base64Decoded(.regular))
+		encoded.removeLast()
+		// This is actually more lenient than the Foundation encoder, which doesn't support missing padding at all.
+		XCTAssertEqual(try encoded.base64Decoded(.regular), Data(bytes: [0]))
+		encoded.removeLast()
+		XCTAssertThrowsError(try encoded.base64Decoded(.regular))
+		encoded.removeLast()
+		XCTAssertEqual(try encoded.base64Decoded(.regular), Data())
+	}
+	
+	func testDecoderWithPaddingExpectsCorrectAmountOfPaddingOrNone2() {
+		var encoded = "AAA="
+		XCTAssertEqual(try encoded.base64Decoded(.regular), Data(bytes: [0, 0]))
+		encoded.removeLast()
+		XCTAssertEqual(try encoded.base64Decoded(.regular), Data(bytes: [0, 0]))
+	}
+	
+	func testDecoderWithPaddingExpectsCorrectAmountOfPaddingOrNone3() {
+		var encoded = "AAAA="
+		XCTAssertThrowsError(try encoded.base64Decoded(.regular))
+		encoded.removeLast()
+		XCTAssertEqual(try encoded.base64Decoded(.regular), Data(bytes: [0, 0, 0]))
+	}
+	
+	func testDecodeThrowsWhenAddingUnexpectedCharactersAfterPadding() {
+		let input = Data(bytes: [1, 2, 3])
+		var encoded = input.base64Encoded(.regular)
+		XCTAssertEqual(try encoded.base64Decoded(.regular), input)
+		
+		encoded.append("=")
+		XCTAssertThrowsError(try encoded.base64Decoded(.regular))
+		encoded.append("=")
+		XCTAssertThrowsError(try encoded.base64Decoded(.regular))
+		encoded.append("=")
+		XCTAssertThrowsError(try encoded.base64Decoded(.regular))
+		encoded.append("=")
+		XCTAssertThrowsError(try encoded.base64Decoded(.regular))
+	}
+	
+	func testDecodeThrowsWhenAddingUnexpectedCharactersAtEnd() {
+		let input = Data(bytes: [1, 2, 3])
+		var encoded = input.base64Encoded(.regular)
+		XCTAssertEqual(try encoded.base64Decoded(.regular), input)
+		
+		encoded.append("A")
+		XCTAssertThrowsError(try encoded.base64Decoded(.regular))
+		encoded.append("A=")
+		XCTAssertThrowsError(try encoded.base64Decoded(.regular))
+	}
+	
+	func testDecodeThrowsWhenAddingUnexpectedPadding() {
+		let input = Data(bytes: [1, 2, 3])
+		var encoded = input.base64Encoded(.url)
+		XCTAssertEqual(try encoded.base64Decoded(.url), input)
+		
+		encoded.append("A")
+		XCTAssertThrowsError(try encoded.base64Decoded(.url))
+		encoded.removeLast()
+		encoded.append("=")
+		XCTAssertThrowsError(try encoded.base64Decoded(.url))
+		encoded.append("A=")
+		XCTAssertThrowsError(try encoded.base64Decoded(.url))
+	}
+	
+	static let allTests = [
+		("testEncodeDecodeRegular", testEncodeDecodeRegular),
+		("testEncodeDecodeNoPadding", testEncodeDecodeNoPadding),
+		("testEncodeDecodeURL", testEncodeDecodeURL),
+		("testDecoderWithPaddingExpectsCorrectAmountOfPaddingOrNone1", testDecoderWithPaddingExpectsCorrectAmountOfPaddingOrNone1),
+		("testDecoderWithPaddingExpectsCorrectAmountOfPaddingOrNone2", testDecoderWithPaddingExpectsCorrectAmountOfPaddingOrNone2),
+		("testDecoderWithPaddingExpectsCorrectAmountOfPaddingOrNone3", testDecoderWithPaddingExpectsCorrectAmountOfPaddingOrNone3),
+		("testDecodeThrowsWhenAddingUnexpectedCharactersAfterPadding", testDecodeThrowsWhenAddingUnexpectedCharactersAfterPadding),
+		("testDecodeThrowsWhenAddingUnexpectedCharactersAtEnd", testDecodeThrowsWhenAddingUnexpectedCharactersAtEnd),
+		("testDecodeThrowsWhenAddingUnexpectedPadding", testDecodeThrowsWhenAddingUnexpectedPadding),
+		]
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -8,6 +8,7 @@ import XCTest
 
 XCTMain([
 	/// Bits
+	testCase(Base64Tests.allTests),
 	testCase(ByteBufferPeekTests.allTests),
 	testCase(ByteBufferRequireTests.allTests),
 


### PR DESCRIPTION
- Fix decoding when the encoded string contains padding characters
- Share all global Base64 instances (they have no state anyway)
- Make `base64Encoded` non-throwing and always return a string
- Add tests