### PR TITLE
Adds Future.each methods

### DIFF
--- a/Sources/Async/Future+Each.swift
+++ b/Sources/Async/Future+Each.swift
@@ -1,0 +1,8 @@
+extension Future where T: Sequence {
+    
+    func each<Wrapped>(to: Wrapped.Type, transform: @escaping (Expectation.Element)throws -> Wrapped) -> Future<[Wrapped]> {
+        return self.map(to: [Wrapped].self, { (this) in
+            return try this.map(transform)
+        })
+    }
+}

--- a/Sources/Async/Future+Each.swift
+++ b/Sources/Async/Future+Each.swift
@@ -1,11 +1,17 @@
 extension Future where T: Sequence {
     
+    /// Iterates over each element of a sequence in a future,
+    /// running a transformation method on each element.
+    /// The result returned should be a non-future type.
     func each<Wrapped>(to: Wrapped.Type, transform: @escaping (Expectation.Element)throws -> Wrapped) -> Future<[Wrapped]> {
         return self.map(to: [Wrapped].self, { (this) in
             return try this.map(transform)
         })
     }
     
+    /// Iterates over each element of a sequence in a future,
+    /// running a transformation method on each element.
+    /// The result returned should be a future.
     func flatEach<Wrapped>(to: Wrapped.Type, transform: @escaping (Expectation.Element)throws -> Future<Wrapped>) -> Future<[Wrapped]> {
         return self.flatMap(to: [Wrapped].self, { (this) in
             return try this.map(transform).flatten(on: self.eventLoop)

--- a/Sources/Async/Future+Each.swift
+++ b/Sources/Async/Future+Each.swift
@@ -5,4 +5,10 @@ extension Future where T: Sequence {
             return try this.map(transform)
         })
     }
+    
+    func flatEach<Wrapped>(to: Wrapped.Type, transform: @escaping (Expectation.Element)throws -> Future<Wrapped>) -> Future<[Wrapped]> {
+        return self.flatMap(to: [Wrapped].self, { (this) in
+            return try this.map(transform).flatten(on: self.eventLoop)
+        })
+    }
 }


### PR DESCRIPTION
Adds `.each` and `flatEach` to the `Future<Sequence>` type.

```swift
let users = Users.all()
users.each(to: Int.self) { user in
    return user.id
}
```

```swift
let users = Users.all()
users.flatEach(to: Metadata.self) { user in
    return user.metadata(on: request)
}
```