### PR TITLE
Fix synchronization issue in QueueHandler

### DIFF
--- a/Sources/Async/QueueHandler.swift
+++ b/Sources/Async/QueueHandler.swift
@@ -90,14 +90,16 @@ public final class QueueHandler<In, Out>: ChannelInboundHandler {
         }
         do {
             if try current.onInput(input) {
-                current.promise.succeed()
                 let popped = inputQueue.popLast()
                 assert(popped != nil)
+                
+                current.promise.succeed()
             }
         } catch {
-            current.promise.fail(error: error)
             let popped = inputQueue.popLast()
             assert(popped != nil)
+            
+            current.promise.fail(error: error)
         }
     }
 


### PR DESCRIPTION
In the event that the current promise triggers another Channel operation serviced by this QueueHandler, channelRead() becomes re-entrant, and crashes with an assertion failure because the last callback in the queue is called twice, and then removed twice.

Instead, tidy up and remove the last handler before satisfying the promise.