### PR TITLE
remove duplicate properties, fixes #119

### DIFF
--- a/Sources/Core/CodableReflection/ReflectionDecoders.swift
+++ b/Sources/Core/CodableReflection/ReflectionDecoders.swift
@@ -41,7 +41,10 @@ final class ReflectionDecoderContext {
 
     /// Adds a property to this `ReflectionDecoderContext`.
     func addProperty<T>(type: T.Type, at path: [CodingKey]) {
-        let property = ReflectedProperty.init(T.self, at: path.map { $0.stringValue })
+        let path = path.map { $0.stringValue }
+        // remove any duplicates, favoring the new type
+        properties = properties.filter { $0.path != path }
+        let property = ReflectedProperty.init(T.self, at: path)
         properties.append(property)
     }
 }

--- a/Tests/CoreTests/ReflectableTests.swift
+++ b/Tests/CoreTests/ReflectableTests.swift
@@ -251,6 +251,17 @@ class ReflectableTests: XCTestCase {
         XCTAssertThrowsError(try Person.reflectProperty(forKey: \.pets))
     }
 
+    func testGH119() throws {
+        enum PetType: Int, Codable {
+            case cat, dog
+        }
+        struct Pet: Reflectable, Codable {
+            var name: String
+            var type: PetType
+        }
+        try XCTAssertEqual(Pet.reflectProperties().description, "[name: String, type: Int]")
+    }
+
     static let allTests = [
         ("testStruct", testStruct),
         ("testStructCustomProperties", testStructCustomProperties),
@@ -262,6 +273,7 @@ class ReflectableTests: XCTestCase {
         ("testCustomCodingKeys", testCustomCodingKeys),
         ("testCache", testCache),
         ("testArrayNested", testArrayNested),
+        ("testGH119", testGH119),
     ]
 }
 

--- a/Tests/CoreTests/ReflectableTests.swift
+++ b/Tests/CoreTests/ReflectableTests.swift
@@ -251,6 +251,7 @@ class ReflectableTests: XCTestCase {
         XCTAssertThrowsError(try Person.reflectProperty(forKey: \.pets))
     }
 
+    /// https://github.com/vapor/core/issues/119
     func testGH119() throws {
         enum PetType: Int, Codable {
             case cat, dog


### PR DESCRIPTION
- [x] `addProperty` now removes duplicate properties first, favoring the last property added
- [x] fixes #119 