### PR TITLE
Fix a memory leak in QueueHandler

### DIFF
--- a/Sources/Async/QueueHandler.swift
+++ b/Sources/Async/QueueHandler.swift
@@ -27,7 +27,7 @@ public final class QueueHandler<In, Out>: ChannelInboundHandler {
     private let eventLoop: EventLoop
 
     /// A write-ready context waiting.
-    private var waitingCtx: ChannelHandlerContext?
+    private weak var waitingCtx: ChannelHandlerContext?
 
     /// Handles errors that happen when no input promise is waiting.
     private var errorHandler: (Error) -> ()


### PR DESCRIPTION
`QueueHandler` sometimes retains the context it is executing on in `waitingCtx`. That context's handler is the `QueueHandler` itself, leading to a retain cycle. We break it by making `waitingCtx` a weak reference.