### PR TITLE
add implicit map/flatMap return types

### DIFF
--- a/Sources/Async/Deprecated.swift
+++ b/Sources/Async/Deprecated.swift
@@ -1,4 +1,5 @@
 extension Future {
+    /// See `cascade(promise:)`.
     @available(*, deprecated, renamed: "cascade(promise:)")
     public func chain(to promise: Promise<T>) {
         self.cascade(promise: promise)
@@ -6,6 +7,7 @@ extension Future {
 }
 
 extension Array where Element == Future<Void> {
+    /// See `flatten(on:)`.
     @available(*, deprecated)
     public func transform<T>(on worker: Worker, to callback: @escaping () throws -> Future<T>) -> Future<T> {
         return flatten(on: worker).flatMap(to: T.self, callback)

--- a/Sources/Async/Future+Map.swift
+++ b/Sources/Async/Future+Map.swift
@@ -13,7 +13,7 @@ extension Future {
     ///     print(futureInt) // Future<Int>
     ///
     /// See `flatMap(to:_:)` for mapping `Future` results to other `Future` types.
-    public func map<T>(to type: T.Type, _ callback: @escaping (Expectation) throws -> T) -> Future<T> {
+    public func map<T>(to type: T.Type = T.self, _ callback: @escaping (Expectation) throws -> T) -> Future<T> {
         let promise = eventLoop.newPromise(T.self)
 
         self.do { expectation in
@@ -42,8 +42,8 @@ extension Future {
     ///     print(futureRes) // Future<Response>
     ///
     /// See `map(to:_:)` for mapping `Future` results to non-`Future` types.
-    public func flatMap<Wrapped>(to type: Wrapped.Type, _ callback: @escaping (Expectation) throws -> Future<Wrapped>) -> Future<Wrapped> {
-        let promise = eventLoop.newPromise(Wrapped.self)
+    public func flatMap<T>(to type: T.Type = T.self, _ callback: @escaping (Expectation) throws -> Future<T>) -> Future<T> {
+        let promise = eventLoop.newPromise(T.self)
 
         self.do { expectation in
             do {


### PR DESCRIPTION
Adds support for implicit `map`/`flatMap` return types. Initially we made these required to minimize issues with type inference but it seems that Swift 4.1 official is actually not having as many problems. Additionally, now that we are using NIO's futures, there _are_ methods available (`map`, `then`, etc) that support not passing any explicit type info. Allowing Vapor's methods to better align with those of NIO will make things feel more cohesive.

Here's a snippet of code from Vapor where this was tested. You can see there's actually no strong type information anywhere (not even `-> Future<String>`) and Swift 4.1 seems to be handling it great. Previously, when one would add `try` Swift would no longer be able to infer a return type. Looks like the Swift team has been hard at work!

```swift
router.get("vapor") { req in
    return try req.client().get("https://vapor.codes").map { res in
        return res.description
    }
}
```