### PR TITLE
change flatten from recursive to iterative

### DIFF
--- a/Sources/Async/Future+Flatten.swift
+++ b/Sources/Async/Future+Flatten.swift
@@ -36,6 +36,10 @@ extension Collection where Element: FutureType {
     /// Flattens an array of futures into a future with an array of results.
     /// - note: the order of the results will match the order of the futures in the input array.
     public func flatten(on worker: Worker) -> Future<[Element.Expectation]> {
+        if count == 0 {
+            return worker.eventLoop.newSucceededFuture(result: [])
+        }
+
         // create promise and array of elements with reservation
         let promise = worker.eventLoop.newPromise([Element.Expectation].self)
 

--- a/Sources/Async/Future+Flatten.swift
+++ b/Sources/Async/Future+Flatten.swift
@@ -36,7 +36,9 @@ extension Collection where Element: FutureType {
     /// Flattens an array of futures into a future with an array of results.
     /// - note: the order of the results will match the order of the futures in the input array.
     public func flatten(on worker: Worker) -> Future<[Element.Expectation]> {
-        if count == 0 {
+        // algorithm won't work unless there is at least one element
+        guard count > 0 else {
+            // just return an empty array
             return worker.eventLoop.newSucceededFuture(result: [])
         }
 

--- a/Tests/AsyncTests/AsyncTests.swift
+++ b/Tests/AsyncTests/AsyncTests.swift
@@ -11,8 +11,31 @@ final class AsyncTests: XCTestCase {
         }
         try XCTAssertEqual(futureAB.wait(), "ab")
     }
+
+    func testFlatten() throws {
+        let loop = EmbeddedEventLoop()
+        let a = loop.newPromise(String.self)
+        let b = loop.newPromise(String.self)
+        let arr: [Future<String>] = [a.futureResult, b.futureResult]
+        let flat = arr.flatten(on: loop)
+        a.succeed(result: "a")
+        b.succeed(result: "b")
+        try XCTAssertEqual(flat.wait(), ["a", "b"])
+    }
+
+    func testFlattenStackOVerflow() throws {
+        let loop = EmbeddedEventLoop()
+        var arr: [Future<Int>] = []
+        let count = 1<<12
+        for i in 0..<count {
+            arr.append(loop.newSucceededFuture(result: i))
+        }
+        try XCTAssertEqual(arr.flatten(on: loop).wait().count, count)
+    }
     
     static let allTests = [
         ("testVariadicMap", testVariadicMap),
+        ("testFlatten", testFlatten),
+        ("testFlattenStackOVerflow", testFlattenStackOVerflow),
     ]
 }

--- a/Tests/AsyncTests/AsyncTests.swift
+++ b/Tests/AsyncTests/AsyncTests.swift
@@ -42,12 +42,19 @@ final class AsyncTests: XCTestCase {
         b.fail(error: "b")
         XCTAssertThrowsError(try arr.flatten(on: loop).wait()) { XCTAssert($0 is String) }
     }
+
+    func testFlattenEmpty() throws {
+        let loop = EmbeddedEventLoop()
+        let arr: [Future<String>] = []
+        try XCTAssertEqual(arr.flatten(on: loop).wait().count, 0)
+    }
     
     static let allTests = [
         ("testVariadicMap", testVariadicMap),
         ("testFlatten", testFlatten),
         ("testFlattenStackOverflow", testFlattenStackOverflow),
         ("testFlattenFail", testFlattenFail),
+        ("testFlattenEmpty", testFlattenEmpty),
     ]
 }
 

--- a/Tests/AsyncTests/AsyncTests.swift
+++ b/Tests/AsyncTests/AsyncTests.swift
@@ -23,7 +23,7 @@ final class AsyncTests: XCTestCase {
         try XCTAssertEqual(flat.wait(), ["a", "b"])
     }
 
-    func testFlattenStackOVerflow() throws {
+    func testFlattenStackOverflow() throws {
         let loop = EmbeddedEventLoop()
         var arr: [Future<Int>] = []
         let count = 1<<12
@@ -32,10 +32,23 @@ final class AsyncTests: XCTestCase {
         }
         try XCTAssertEqual(arr.flatten(on: loop).wait().count, count)
     }
+
+    func testFlattenFail() throws {
+        let loop = EmbeddedEventLoop()
+        let a = loop.newPromise(String.self)
+        let b = loop.newPromise(String.self)
+        let arr: [Future<String>] = [a.futureResult, b.futureResult]
+        a.succeed(result: "a")
+        b.fail(error: "b")
+        XCTAssertThrowsError(try arr.flatten(on: loop).wait()) { XCTAssert($0 is String) }
+    }
     
     static let allTests = [
         ("testVariadicMap", testVariadicMap),
         ("testFlatten", testFlatten),
-        ("testFlattenStackOVerflow", testFlattenStackOVerflow),
+        ("testFlattenStackOverflow", testFlattenStackOverflow),
+        ("testFlattenFail", testFlattenFail),
     ]
 }
+
+extension String: Error { }

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,12 @@ jobs:
       - run: 
           name: Run unit tests
           command: swift test
+
+  linux-release:
+    docker:
+      - image: codevapor/swift:4.1
+    steps:
+      - checkout
       - run: 
           name: Compile code with optimizations
           command: swift build -c release
@@ -169,6 +175,7 @@ workflows:
       - linux-redis
       - linux-jwt
       - linux-leaf
+      - linux-release
 #      - macos
 
   nightly:


### PR DESCRIPTION
- [x] `flatten(on:)` now uses an iterative algorithm
- [x] added tests to ensure `flatten(on:)` won't create stack overflow