### PR TITLE
Add convenience method for transforming to void

### DIFF
--- a/Sources/Async/Future+Void.swift
+++ b/Sources/Async/Future+Void.swift
@@ -13,3 +13,12 @@ extension Future where T == Void {
         return promise.futureResult
     }
 }
+
+extension Future where T == Void {
+    /// Convenience function for returning void inside a future
+    public static var void: Void {
+        return _void
+    }
+}
+
+private let _void: Void = {}()

--- a/Sources/Async/Future+Void.swift
+++ b/Sources/Async/Future+Void.swift
@@ -17,8 +17,6 @@ extension Future where T == Void {
 extension Future where T == Void {
     /// Convenience function for returning void inside a future
     public static var void: Void {
-        return _void
+        return ()
     }
 }
-
-private let _void: Void = {}()


### PR DESCRIPTION
Allows you to do

```swift
myFuture.transform(to: Future.void)
```

Moved from vapor-community/async#55