### PR TITLE
Allow optionals filtering in Reflectable

### DIFF
--- a/Sources/Core/Reflectable.swift
+++ b/Sources/Core/Reflectable.swift
@@ -103,8 +103,8 @@ public protocol AnyReflectable {
     ///
     /// - parameters:
     /// 	- depth: The level of nesting to use.
-    ///              	If `0`, the top-most properties will be returned.
-    ///                 If `1`, the first layer of nested properties, and so-on.
+    ///              If `0`, the top-most properties will be returned.
+    ///              If `1`, the first layer of nested properties, and so-on.
     /// - throws: Any error reflecting this type's properties.
     /// - returns: All `ReflectedProperty`s at the specified depth.
     static func reflectProperties(depth: Int) throws -> [ReflectedProperty]

--- a/Sources/Core/Reflectable.swift
+++ b/Sources/Core/Reflectable.swift
@@ -63,12 +63,14 @@ public protocol Reflectable {
     ///     try User.reflectProperties(depth: 0) // [id: UUID?, name: String, pet: Pet]
     ///     try User.reflectProperties(depth: 1) // [pet.name: String, pet.age: Int]
     ///
-    /// - parameters: depth: The level of nesting to use.
-    ///                      If `0`, the top-most properties will be returned.
-    ///                      If `1`, the first layer of nested properties, and so-on.
+    /// - parameters:
+    /// 	- depth: The level of nesting to use.
+    ///              	If `0`, the top-most properties will be returned.
+    ///                 If `1`, the first layer of nested properties, and so-on.
+    ///		- includeOptionals: Whether Optional properties should be included or not.
     /// - throws: Any error reflecting this type's properties.
     /// - returns: All `ReflectedProperty`s at the specified depth.
-    static func reflectProperties(depth: Int) throws -> [ReflectedProperty]
+    static func reflectProperties(depth: Int, includeOptionals: Bool) throws -> [ReflectedProperty]
 
     /// Returns a `ReflectedProperty` for the supplied key path.
     ///
@@ -95,8 +97,14 @@ public protocol Reflectable {
 
 extension Reflectable {
     /// Reflects all of this type's `ReflectedProperty`s.
-    public static func reflectProperties() throws -> [ReflectedProperty] {
-        return try reflectProperties(depth: 0)
+    public static func reflectProperties(includeOptionals: Bool = true) throws -> [ReflectedProperty] {
+        if includeOptionals {
+        	return try reflectProperties(depth: 0)
+    	} else {
+    		return try reflectProperties(depth: 0)
+    			// remove optionals
+            	.filter({ !($0.type is AnyOptionalType.Type) })
+    	}
     }
 }
 

--- a/Sources/Core/Reflectable.swift
+++ b/Sources/Core/Reflectable.swift
@@ -102,7 +102,7 @@ public protocol AnyReflectable {
     ///     try User.reflectProperties(depth: 1) // [pet.name: String, pet.age: Int]
     ///
     /// - parameters:
-    /// 	- depth: The level of nesting to use.
+    ///     - depth: The level of nesting to use.
     ///              If `0`, the top-most properties will be returned.
     ///              If `1`, the first layer of nested properties, and so-on.
     /// - throws: Any error reflecting this type's properties.

--- a/Sources/Core/Reflectable.swift
+++ b/Sources/Core/Reflectable.swift
@@ -67,10 +67,9 @@ public protocol Reflectable {
     /// 	- depth: The level of nesting to use.
     ///              	If `0`, the top-most properties will be returned.
     ///                 If `1`, the first layer of nested properties, and so-on.
-    ///		- includeOptionals: Whether Optional properties should be included or not.
     /// - throws: Any error reflecting this type's properties.
     /// - returns: All `ReflectedProperty`s at the specified depth.
-    static func reflectProperties(depth: Int, includeOptionals: Bool) throws -> [ReflectedProperty]
+    static func reflectProperties(depth: Int) throws -> [ReflectedProperty]
 
     /// Returns a `ReflectedProperty` for the supplied key path.
     ///
@@ -97,6 +96,8 @@ public protocol Reflectable {
 
 extension Reflectable {
     /// Reflects all of this type's `ReflectedProperty`s.
+    /// - parameters:
+    ///      - includeOptionals: Whether Optional properties should be included or not.
     public static func reflectProperties(includeOptionals: Bool = true) throws -> [ReflectedProperty] {
         if includeOptionals {
         	return try reflectProperties(depth: 0)

--- a/Sources/Core/Reflectable.swift
+++ b/Sources/Core/Reflectable.swift
@@ -134,13 +134,6 @@ public protocol AnyReflectable {
     static func anyReflectProperty(valueType: Any.Type, keyPath: AnyKeyPath) throws -> ReflectedProperty?
 }
 
-extension Reflectable {
-    /// Reflects all of this type's `ReflectedProperty`s.
-    public static func reflectProperties() throws -> [ReflectedProperty] {
-        return try reflectProperties(depth: 0)
-    }
-}
-
 /// Represents a property on a type that has been reflected using the `Reflectable` protocol.
 ///
 ///     let property = try User.reflectProperty(forKey: \.pet.name)

--- a/Sources/Core/Reflectable.swift
+++ b/Sources/Core/Reflectable.swift
@@ -103,7 +103,7 @@ extension Reflectable {
         	return try reflectProperties(depth: 0)
     	} else {
     		return try reflectProperties(depth: 0)
-    			// remove optionals
+    			/// remove optionals
             	.filter({ !($0.type is AnyOptionalType.Type) })
     	}
     }

--- a/Tests/CoreTests/ReflectableTests.swift
+++ b/Tests/CoreTests/ReflectableTests.swift
@@ -62,7 +62,7 @@ class ReflectableTests: XCTestCase {
             var osarr: [String]?
         }
 
-        let properties = try Foo.reflectProperties(includeOptionals: false)
+        let properties = try Foo.reflectProperties().optionalsRemoved()
         XCTAssertEqual(properties.description, "[bool: Bool, int: Int, sarr: Array<String>]")
 
         try XCTAssertEqual(Foo.reflectProperty(forKey: \.bool)?.path, ["bool"])

--- a/Tests/CoreTests/ReflectableTests.swift
+++ b/Tests/CoreTests/ReflectableTests.swift
@@ -52,6 +52,27 @@ class ReflectableTests: XCTestCase {
         try XCTAssert(Foo.reflectProperty(forKey: \.odir)?.type is Direction?.Type)
     }
 
+    func testNonOptionalsOnly() throws {
+        struct Foo: Reflectable, Decodable {
+            var bool: Bool
+            var obool: Bool?
+            var int: Int
+            var oint: Int?
+            var sarr: [String]
+            var osarr: [String]?
+        }
+
+        let properties = try Foo.reflectProperties(includeOptionals: false)
+        XCTAssertEqual(properties.description, "[bool: Bool, int: Int, sarr: Array<String>]")
+
+        try XCTAssertEqual(Foo.reflectProperty(forKey: \.bool)?.path, ["bool"])
+        try XCTAssert(Foo.reflectProperty(forKey: \.bool)?.type is Bool.Type)
+        try XCTAssertEqual(Foo.reflectProperty(forKey: \.int)?.path, ["int"])
+        try XCTAssert(Foo.reflectProperty(forKey: \.int)?.type is Int.Type)
+        try XCTAssertEqual(Foo.reflectProperty(forKey: \.sarr)?.path, ["sarr"])
+        try XCTAssert(Foo.reflectProperty(forKey: \.sarr)?.type is [String].Type)
+    }
+
     func testStructCustomProperties() throws {
         struct User: Reflectable {
             var firstName: String
@@ -265,6 +286,7 @@ class ReflectableTests: XCTestCase {
 
     static let allTests = [
         ("testStruct", testStruct),
+        ("testNonOptionalsOnly", testNonOptionalsOnly),
         ("testStructCustomProperties", testStructCustomProperties),
         ("testNestedStruct", testNestedStruct),
         ("testProperties", testProperties),


### PR DESCRIPTION
Found it useful when playing around with GraphQL queries. Merge if needed 😉 

It's a soft filter ofc, optionals shouldn't even the processed

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests). (db timeouts)
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.