### PR TITLE
[Swift 4.2] ReflectionDecodable extension for CaseIterable enums

### DIFF
--- a/Sources/Core/CodableReflection/ReflectionDecodable.swift
+++ b/Sources/Core/CodableReflection/ReflectionDecodable.swift
@@ -236,3 +236,35 @@ func forceCast<T>(_ type: T.Type) throws -> AnyReflectionDecodable.Type {
     }
     return casted
 }
+
+#if swift(>=4.2)
+extension ReflectionDecodable where Self: CaseIterable {
+
+    /// Default implementation of `ReflectionDecodable` for enums that are also `CaseIterable`.
+    ///
+    /// See `ReflectionDecodable.reflectDecoded(_:)` for more information.
+    public static func reflectDecoded() throws -> (Self, Self) {
+        /// enum must have at least 2 cases
+        guard !allCases.isEmpty, allCases.count > 1 else {
+            throw CoreError(
+                identifier: "ReflectionDecodable",
+                reason: "\(T.self) must have at least 2 cases",
+                suggestedFixes: [
+                    "Add at least 2 cases to the enum."
+                ]
+            )
+        }
+        /// cases should be different
+        guard let first = allCases.first, let last = allCases.last else {
+            throw CoreError(
+                identifier: "ReflectionDecodable",
+                reason: "\(T.self) must have at least 2 cases",
+                suggestedFixes: [
+                    "Add at least 2 cases to the enum."
+                ]
+            )
+        }
+        return (first, last)
+    }
+}
+#endif

--- a/Sources/Core/CodableReflection/ReflectionDecodable.swift
+++ b/Sources/Core/CodableReflection/ReflectionDecodable.swift
@@ -244,25 +244,16 @@ extension ReflectionDecodable where Self: CaseIterable {
     ///
     /// See `ReflectionDecodable.reflectDecoded(_:)` for more information.
     public static func reflectDecoded() throws -> (Self, Self) {
-        /// enum must have at least 2 cases
-        guard !allCases.isEmpty, allCases.count > 1 else {
-            throw CoreError(
-                identifier: "ReflectionDecodable",
-                reason: "\(T.self) must have at least 2 cases",
-                suggestedFixes: [
-                    "Add at least 2 cases to the enum."
-                ]
-            )
-        }
-        /// cases should be different
-        guard let first = allCases.first, let last = allCases.last else {
-            throw CoreError(
-                identifier: "ReflectionDecodable",
-                reason: "\(T.self) must have at least 2 cases",
-                suggestedFixes: [
-                    "Add at least 2 cases to the enum."
-                ]
-            )
+        /// enum must have at least 2 unique cases
+        guard !allCases.isEmpty, allCases.count > 1,
+            let first = allCases.first, let last = allCases.last else {
+                throw CoreError(
+                    identifier: "ReflectionDecodable",
+                    reason: "\(T.self) must have at least 2 cases",
+                    suggestedFixes: [
+                        "Add at least 2 cases to the enum."
+                    ]
+                )
         }
         return (first, last)
     }

--- a/Sources/Core/CodableReflection/ReflectionDecodable.swift
+++ b/Sources/Core/CodableReflection/ReflectionDecodable.swift
@@ -246,10 +246,10 @@ extension ReflectionDecodable where Self: CaseIterable {
     public static func reflectDecoded() throws -> (Self, Self) {
         /// enum must have at least 2 unique cases
         guard !allCases.isEmpty, allCases.count > 1,
-            let first = allCases.first, let last = allCases.last else {
+            let first = allCases.first, let last = allCases.suffix(1).first else {
                 throw CoreError(
                     identifier: "ReflectionDecodable",
-                    reason: "\(T.self) must have at least 2 cases",
+                    reason: "\(Self.self) enum must have at least 2 cases",
                     suggestedFixes: [
                         "Add at least 2 cases to the enum."
                     ]

--- a/Sources/Core/CodableReflection/ReflectionDecodable.swift
+++ b/Sources/Core/CodableReflection/ReflectionDecodable.swift
@@ -245,7 +245,7 @@ extension ReflectionDecodable where Self: CaseIterable {
     /// See `ReflectionDecodable.reflectDecoded(_:)` for more information.
     public static func reflectDecoded() throws -> (Self, Self) {
         /// enum must have at least 2 unique cases
-        guard !allCases.isEmpty, allCases.count > 1,
+        guard allCases.count > 1,
             let first = allCases.first, let last = allCases.suffix(1).first else {
                 throw CoreError(
                     identifier: "ReflectionDecodable",

--- a/Tests/CoreTests/ReflectableTests.swift
+++ b/Tests/CoreTests/ReflectableTests.swift
@@ -55,7 +55,7 @@ class ReflectableTests: XCTestCase {
     func testCaseIterableExtension() throws {
         #if swift(>=4.2)
         enum Pet: String, CaseIterable, ReflectionDecodable, Decodable {
-            case cat
+            case cat, dog
         }
 
         struct Foo: Reflectable, Decodable {

--- a/Tests/CoreTests/ReflectableTests.swift
+++ b/Tests/CoreTests/ReflectableTests.swift
@@ -52,6 +52,31 @@ class ReflectableTests: XCTestCase {
         try XCTAssert(Foo.reflectProperty(forKey: \.odir)?.type is Direction?.Type)
     }
 
+    func testCaseIterableExtension() throws {
+        #if swift(>=4.2)
+        enum Pet: String, CaseIterable, ReflectionDecodable, Decodable {
+            case cat
+        }
+
+        struct Foo: Reflectable, Decodable {
+            var bool: Bool
+            var pet: Pet
+        }
+
+        let properties = try Foo.reflectProperties()
+        XCTAssertEqual(properties.description, """
+        [bool: Bool, pet: Pet]
+        """)
+
+        try XCTAssertEqual(Foo.reflectProperty(forKey: \.bool)?.path, ["bool"])
+        try XCTAssert(Foo.reflectProperty(forKey: \.bool)?.type is Bool.Type)
+        try XCTAssertEqual(Foo.reflectProperty(forKey: \.pet)?.path, ["pet"])
+        try XCTAssert(Foo.reflectProperty(forKey: \.pet)?.type is Pet.Type)
+        #else
+        XCTAssertTrue(true)
+        #endif
+    }
+
     func testNonOptionalsOnly() throws {
         struct Foo: Reflectable, Decodable {
             var bool: Bool
@@ -286,6 +311,7 @@ class ReflectableTests: XCTestCase {
 
     static let allTests = [
         ("testStruct", testStruct),
+        ("testCaseIterableExtension", testCaseIterableExtension),
         ("testNonOptionalsOnly", testNonOptionalsOnly),
         ("testStructCustomProperties", testStructCustomProperties),
         ("testNestedStruct", testNestedStruct),

--- a/Tests/CoreTests/ReflectableTests.swift
+++ b/Tests/CoreTests/ReflectableTests.swift
@@ -54,6 +54,11 @@ class ReflectableTests: XCTestCase {
 
     func testCaseIterableExtension() throws {
         #if swift(>=4.2)
+        // Should throw since there's only 1 case
+        enum FakePet: String, CaseIterable, ReflectionDecodable, Decodable {
+            case dragon
+        }
+
         enum Pet: String, CaseIterable, ReflectionDecodable, Decodable {
             case cat, dog
         }
@@ -75,6 +80,8 @@ class ReflectableTests: XCTestCase {
         #else
         XCTAssertTrue(true)
         #endif
+
+        try XCTAssertThrowsError(FakePet.reflectDecoded(), "FakePet should throw")
     }
 
     func testNonOptionalsOnly() throws {


### PR DESCRIPTION
Depends on Swift 4.2 (shim could be added for Swift <= 4.1)

Closes #148 

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
  - See https://github.com/vapor/core/pull/152#issuecomment-393339880
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
