### PR TITLE
Created Worker.future() method

### DIFF
--- a/Sources/Async/Worker.swift
+++ b/Sources/Async/Worker.swift
@@ -42,6 +42,15 @@ extension Worker {
         return next()
     }
     
+    /// Creates a new, succeeded `Future` from the worker's event loop with a `Void` value.
+    ///
+    ///    let a: Future<Void> = req.future()
+    ///
+    /// - returns: The succeeded future.
+    public func future() -> Future<Void> {
+        return self.eventLoop.newSucceededFuture(result: ())
+    }
+    
     /// Creates a new, succeeded `Future` from the worker's event loop.
     ///
     ///    let a: Future<String> = req.future("hello")


### PR DESCRIPTION
Adds a `.future()` method to the `Worker` protocol that creates a new, succeeded, future with a `Void` value.

```swift
let success: Future<Void> = request.future()
```