### PR TITLE
only define shim CaseIterable if < Swift 4.2 _compiler_

### DIFF
--- a/Sources/Core/CodableReflection/ReflectionDecodable.swift
+++ b/Sources/Core/CodableReflection/ReflectionDecodable.swift
@@ -226,7 +226,7 @@ func forceCast<T>(_ type: T.Type) throws -> AnyReflectionDecodable.Type {
     return casted
 }
 
-#if swift(>=4.2)
+#if swift(>=4.1.50)
 #else
 public protocol CaseIterable {
     static var allCases: [Self] { get }


### PR DESCRIPTION
Swift 4.2 compiler defines `CaseIterable` even if it is compiling in a compatibility mode. This PR uses a hack that the Swift team has given us until the `#compiler` directive is available to determine whether or not we are using the Swift 4.2 _compiler_ in lieu of just checking the version.