### PR TITLE
Minor: Fix typo in comment

### DIFF
--- a/Sources/Core/Reflectable.swift
+++ b/Sources/Core/Reflectable.swift
@@ -45,7 +45,7 @@
 ///     }
 ///
 /// Even if your type gets the default implementation for being `Decodable`, you can still override both
-/// the `reflectProperties(dpeth:)` and `reflectProperty(forKey:)` methods.
+/// the `reflectProperties(depth:)` and `reflectProperty(forKey:)` methods.
 public protocol Reflectable: AnyReflectable {
 
     /// Returns a `ReflectedProperty` for the supplied key path.


### PR DESCRIPTION
This PR just fixes a tiny typo in a doc comment.