### PR TITLE
Fixed MIME type detection

### DIFF
--- a/Sources/Core/File.swift
+++ b/Sources/Core/File.swift
@@ -8,7 +8,7 @@ public struct File: Codable {
 
     /// Associated `MediaType` for this file's extension, if it has one.
     public var contentType: MediaType? {
-        return ext.flatMap { MediaType.fileExtension($0) }
+        return ext.flatMap { MediaType.fileExtension($0.lowercased()) }
     }
 
     /// The file extension, if it has one.


### PR DESCRIPTION
The MIME type detection was previously not working for files with an extension written in uppercase. For example, `image.jpg` would resolve to `image/jpeg` whereas `image.JPG` would return `nil` instead.