### PR TITLE
Created Future.transform(to:Future<T>) method

### DIFF
--- a/Sources/Async/Future+Transform.swift
+++ b/Sources/Async/Future+Transform.swift
@@ -10,4 +10,15 @@ extension Future {
             instance
         }
     }
+    
+    /// Maps the current future to contain the new type. Errors are carried over, successful (expected) results are transformed into the given instance.
+    ///
+    ///     let user = User.find(id, on: request)
+    ///     posts.save(on: request).transform(to: user)
+    ///
+    public func transform<T>(to future: Future<T>) -> Future<T> {
+        return self.flatMap(to: T.self) { _ in
+            future
+        }
+    }
 }


### PR DESCRIPTION
Maps the current future to contain the new type. Errors are carried over, successful (expected) results are transformed into the given instance. This is the same as `Future.transform(to:T)`, but it takes in a future.

```swift
let user = User.find(id, on: request)
posts.save(on: request).transform(to: user)
```