### PR TITLE
Conform NSError to Debuggable

### DIFF
--- a/Sources/Debugging/NSError+Debuggable.swift
+++ b/Sources/Debugging/NSError+Debuggable.swift
@@ -11,4 +11,18 @@ extension NSError: Debuggable {
     public var reason: String {
         return self.debugDescription
     }
+    
+    public var possibleCauses: [String] {
+        if let reason =  self.localizedFailureReason {
+            return [reason]
+        }
+        return []
+    }
+    
+    public var suggestedFixes: [String] {
+        if let suggestion = self.localizedRecoverySuggestion {
+            return [suggestion]
+        }
+        return []
+    }
 }

--- a/Sources/Debugging/NSError+Debuggable.swift
+++ b/Sources/Debugging/NSError+Debuggable.swift
@@ -4,7 +4,7 @@ extension NSError: Debuggable {
     
     /// See `Debuggable`
     public var identifier: String {
-        return "\(self.debugDescription)_\(Int.random(in: 0...1000))"
+        return "\(self.code)"
     }
     
     /// See `Debuggable`

--- a/Sources/Debugging/NSError+Debuggable.swift
+++ b/Sources/Debugging/NSError+Debuggable.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension NSError: Debuggable {
+    
+    /// See `Debuggable`
+    public var identifier: String {
+        return "\(self.debugDescription)_\(Int.random(in: 0...1000))"
+    }
+    
+    /// See `Debuggable`
+    public var reason: String {
+        return self.debugDescription
+    }
+}


### PR DESCRIPTION
Fixing annoying non saying errors like this:
```
[ ERROR ] The operation could not be completed (ErrorMiddleware.swift:26)
[ DEBUG ] Conform `NSError` to `Debuggable` for better debug info. (ErrorMiddleware.swift:26)
```
Wasn't sure how "unique" the identifier should be, so included a random integer, for the reason just included the `debugDescription`