### PR TITLE
Support sync flatten for an array of generic lazy futures

### DIFF
--- a/Sources/Async/Future+Flatten.swift
+++ b/Sources/Async/Future+Flatten.swift
@@ -3,20 +3,24 @@
 /// A closure that returns a future.
 public typealias LazyFuture<T> = () throws -> Future<T>
 
-extension Collection where Element == LazyFuture<Void> {
+extension Collection {
     /// Flattens an array of lazy futures into a future with an array of results.
     /// - note: each subsequent future will wait for the previous to complete before starting.
-    public func syncFlatten(on worker: Worker) -> Future<Void> {
-        let promise = worker.eventLoop.newPromise(Void.self)
-
+    public func syncFlatten<T>(on worker: Worker) -> Future<[T]> where Element == LazyFuture<T> {
+        let promise = worker.eventLoop.newPromise([T].self)
+        
+        var elements: [T] = []
+        elements.reserveCapacity(self.count)
+        
         var iterator = makeIterator()
-        func handle(_ future: LazyFuture<Void>) {
+        func handle(_ future: LazyFuture<T>) {
             do {
                 try future().do { res in
+                    elements.append(res)
                     if let next = iterator.next() {
                         handle(next)
                     } else {
-                        promise.succeed()
+                        promise.succeed(result: elements)
                     }
                 }.catch { error in
                     promise.fail(error: error)
@@ -29,10 +33,19 @@ extension Collection where Element == LazyFuture<Void> {
         if let first = iterator.next() {
             handle(first)
         } else {
-            promise.succeed()
+            promise.succeed(result: elements)
         }
 
         return promise.futureResult
+    }
+}
+
+extension Collection where Element == LazyFuture<Void> {
+    /// Flattens an array of lazy void futures into a single void future.
+    /// - note: each subsequent future will wait for the previous to complete before starting.
+    public func syncFlatten(on worker: Worker) -> Future<Void> {
+        let flatten: Future<[Void]> = self.syncFlatten(on: worker)
+        return flatten.transform(to: ())
     }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ jobs:
       - run: swift test
   linux:
     docker:
-      - image: swift:4.2
+      - image: codevapor/swift:4.1
     steps:
       - checkout
       - run: 

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ jobs:
       - run: swift test
   linux:
     docker:
-      - image: codevapor/swift:4.1
+      - image: swift:4.2
     steps:
       - checkout
       - run: 
@@ -22,7 +22,7 @@ jobs:
 
   linux-release:
     docker:
-      - image: codevapor/swift:4.1
+      - image: swift:4.2
     steps:
       - checkout
       - run: 
@@ -30,11 +30,11 @@ jobs:
           command: swift build -c release
   linux-vapor:
     docker:
-      - image: codevapor/swift:4.1
+      - image: swift:4.2
     steps:
       - run:
           name: Clone Vapor
-          command: git clone -b master https://github.com/vapor/vapor.git
+          command: git clone -b 3 https://github.com/vapor/vapor.git
           working_directory: ~/
       - run:
           name: Switch Vapor to this Core revision
@@ -46,7 +46,7 @@ jobs:
           working_directory: ~/vapor
   linux-fluent-sqlite:
     docker:
-      - image: codevapor/swift:4.1
+      - image: swift:4.2
     steps:
       - run:
           name: Clone Fluent SQLite
@@ -62,7 +62,7 @@ jobs:
           working_directory: ~/fluent-sqlite
   linux-fluent-mysql:
     docker:
-      - image: codevapor/swift:4.1
+      - image: swift:4.2
       - image: mysql:5.7
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
@@ -85,7 +85,7 @@ jobs:
           working_directory: ~/fluent-mysql
   linux-fluent-postgresql:
     docker:
-      - image: codevapor/swift:4.1
+      - image: swift:4.2
       - image: circleci/postgres:latest
         name: psql
         environment:
@@ -95,7 +95,7 @@ jobs:
     steps:
       - run:
           name: Clone Fluent PostgreSQL
-          command: git clone -b master https://github.com/vapor/fluent-postgresql.git
+          command: git clone -b 1 https://github.com/vapor/fluent-postgresql.git
           working_directory: ~/
       - run:
           name: Switch Fluent PostgreSQL to this Core revision
@@ -107,7 +107,7 @@ jobs:
           working_directory: ~/fluent-postgresql
   linux-redis:
     docker:
-      - image: codevapor/swift:4.1
+      - image: swift:4.2
       - image: redis:3.2
     steps:
       - run:
@@ -124,7 +124,7 @@ jobs:
           working_directory: ~/redis
   linux-jwt:
     docker:
-      - image: codevapor/swift:4.1
+      - image: swift:4.2
     steps:
       - run:
           name: Clone JWT
@@ -140,7 +140,7 @@ jobs:
           working_directory: ~/jwt
   linux-leaf:
     docker:
-      - image: codevapor/swift:4.1
+      - image: swift:4.2
     steps:
       - run:
           name: Clone Leaf


### PR DESCRIPTION
This adds support for `syncFlatten` on an array of generic lazy futures.

[Issue #82 on vapor-community/async](https://github.com/vapor-community/async/issues/82) has additional details and discussion around implementation options.

I've submitted a related PR to https://github.com/vapor-community/async/pull/83. As mentioned on that PR, it looks like there is a transition under way between core, async, and nio-kit repos for these future helpers. 

I'd like to target Vapor 3 with this change. Any feedback on code / where this PR should be open is appreciated.

Cheers,
Will