### PR TITLE
Consolidate Debuggable.stackTrace with the rest of the error types

### DIFF
--- a/Sources/Debugging/Debuggable.swift
+++ b/Sources/Debugging/Debuggable.swift
@@ -28,7 +28,7 @@ public protocol Debuggable: CustomDebugStringConvertible, CustomStringConvertibl
     var sourceLocation: SourceLocation? { get }
 
     /// Stack trace from which this error originated (must set this from the error's init)
-    var stackTrace: [String]? { get }
+    var stackTrace: [String] { get }
 
     /// A `String` array describing the possible causes of the error.
     /// - note: Defaults to an empty array.
@@ -117,8 +117,8 @@ extension Debuggable {
     }
 
     /// See `Debuggable`
-    public var stackTrace: [String]? {
-        return nil
+    public var stackTrace: [String] {
+        return []
     }
 }
 


### PR DESCRIPTION
References: https://github.com/vapor/vapor/issues/1804

The `stackTrace` was optional and was unreachable by trying cast `error: Error` to `Debuggable`, it was always returning nil.