### PR TITLE
Wrap the argument to `Future.transform` in an autoclosure

### DIFF
--- a/Sources/Async/Future+Transform.swift
+++ b/Sources/Async/Future+Transform.swift
@@ -5,9 +5,9 @@ extension Future {
     ///
     ///     user.save(on: req).transform(to: HTTPStatus.created)
     ///
-    public func transform<T>(to instance: T) -> Future<T> {
+    public func transform<T>(to instance: @escaping @autoclosure () -> T) -> Future<T> {
         return self.map(to: T.self) { _ in
-            instance
+            instance()
         }
     }
     


### PR DESCRIPTION
This avoids creating the argument if it won't be needed at all, e.g. because a previous future fails.