### PR TITLE
swift 5 #compiler check

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.1
 import PackageDescription
 
 let package = Package(

--- a/Sources/Core/CaseInsensitiveString.swift
+++ b/Sources/Core/CaseInsensitiveString.swift
@@ -17,10 +17,18 @@ public struct CaseInsensitiveString: ExpressibleByStringLiteral, Comparable, Equ
     /// Internal `String` storage.
     private let storage: String
     
+    // #if compiler(>=4.2)
+    #if swift(>=4.1.50)
+    /// See `Hashable`.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.storage.lowercased())
+    }
+    #else
     /// See `Hashable`.
     public var hashValue: Int {
         return self.storage.lowercased().hashValue
     }
+    #endif
 
     /// See `CustomStringConvertible`.
     public var description: String {

--- a/Sources/Core/MediaType.swift
+++ b/Sources/Core/MediaType.swift
@@ -122,15 +122,28 @@ public struct MediaType: Hashable, CustomStringConvertible, Equatable {
         return serialize()
     }
 
+    // #if compiler(>=4.2)
+    #if swift(>=4.1.50)
     /// See `Hashable`.
-    public let hashValue: Int
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self._hashValue)
+    }
+    #else
+    /// See `Hashable`.
+    public var hashValue: Int {
+        return self._hashValue
+    }
+    #endif
+    
+    /// Hash value storage.
+    private let _hashValue: Int
 
     /// Create a new `MediaType`.
     public init(type: String, subType: String, parameters: [CaseInsensitiveString: String] = [:]) {
         self.type = type
         self.subType = subType
         self.parameters = parameters
-        self.hashValue = type.hashValue &+ subType.hashValue
+        self._hashValue = type.hashValue &+ subType.hashValue
     }
 
     /// Parse a `MediaType` from a `String`.

--- a/Tests/CoreTests/ReflectableTests.swift
+++ b/Tests/CoreTests/ReflectableTests.swift
@@ -27,9 +27,16 @@ class ReflectableTests: XCTestCase {
         }
 
         let properties = try Foo.reflectProperties()
+        
+        #if swift(>=4.1.50)
         XCTAssertEqual(properties.description, """
         [bool: Bool, obool: Optional<Bool>, int: Int, oint: Optional<Int>, sarr: Array<String>, osarr: Optional<Array<String>>, pet: Pet, opet: Optional<Pet>, dir: Direction, odir: Optional<Direction>]
         """)
+        #else
+        XCTAssertEqual(properties.description, """
+        [bool: Bool, obool: Optional<Bool>, int: Int, oint: Optional<Int>, sarr: Array<String>, osarr: Optional<Array<String>>, pet: Pet #1, opet: Optional<Pet #1>, dir: Direction #1, odir: Optional<Direction #1>]
+        """)
+        #endif
 
         try XCTAssertEqual(Foo.reflectProperty(forKey: \.bool)?.path, ["bool"])
         try XCTAssert(Foo.reflectProperty(forKey: \.bool)?.type is Bool.Type)
@@ -233,7 +240,11 @@ class ReflectableTests: XCTestCase {
             var age: Int
         }
 
+        #if swift(>=4.1.50)
         try XCTAssertEqual(User.reflectProperties(depth: 0).description, "[id: Optional<UUID>, pet: Pet, name: String, age: Int]")
+        #else
+        try XCTAssertEqual(User.reflectProperties(depth: 0).description, "[id: Optional<UUID>, pet: Pet #1, name: String, age: Int]")
+        #endif
         try XCTAssertEqual(User.reflectProperties(depth: 1).description, "[pet.name: String, pet.age: Int]")
         try XCTAssertEqual(User.reflectProperties(depth: 2).description, "[]")
     }
@@ -308,7 +319,11 @@ class ReflectableTests: XCTestCase {
             var pets: [Pet]
         }
 
+        #if swift(>=4.1.50)
         try XCTAssertEqual(Person.reflectProperties().description, "[id: Optional<Int>, title: String, pets: Array<Pet>]")
+        #else
+        try XCTAssertEqual(Person.reflectProperties().description, "[id: Optional<Int>, title: String, pets: Array<Pet #1>]")
+        #endif
         XCTAssertThrowsError(try Person.reflectProperty(forKey: \.pets))
     }
 


### PR DESCRIPTION
Gets rid of two additional warnings by using `#if swift(>=4.1.50)`