### PR TITLE
Significantly improve the performance of `Collection<FutureType>.flatten

### DIFF
--- a/Sources/Async/FutureType.swift
+++ b/Sources/Async/FutureType.swift
@@ -10,6 +10,9 @@ public protocol FutureType {
     /// This future's result type.
     typealias Result = FutureResult<Expectation>
 
+    /// The event loop this future is fulfilled on.
+    var eventLoop: EventLoop { get }
+
     /// Adds a new awaiter to this `Future` that will be called when the result is ready.
     func addAwaiter(callback: @escaping FutureResultCallback<Expectation>)
 }

--- a/Tests/AsyncTests/AsyncTests.swift
+++ b/Tests/AsyncTests/AsyncTests.swift
@@ -63,7 +63,17 @@ final class AsyncTests: XCTestCase {
             timeoutTask.cancel()
             
         }
-        
+    }
+
+    func testFlattenPerformance() throws {
+        let loop = EmbeddedEventLoop()
+        let expected = Array(0..<200_000)
+        let futures = expected.map { loop.newSucceededFuture(result: $0) }
+        var futureResult: [Int] = []
+        measure {
+            futureResult = try! futures.flatten(on: loop).wait()
+        }
+        XCTAssertEqual(futureResult, expected)
     }
     
     func testSyncFlatten() throws {
@@ -131,7 +141,8 @@ final class AsyncTests: XCTestCase {
         ("testFlattenStackOverflow", testFlattenStackOverflow),
         ("testFlattenFail", testFlattenFail),
         ("testFlattenEmpty", testFlattenEmpty),
-        ("testFlattenStress", testFlattenStress)
+        ("testFlattenStress", testFlattenStress),
+        ("testFlattenPerformance", testFlattenPerformance)
     ]
 }
 


### PR DESCRIPTION
This further halves the runtime in https://github.com/vapor/template-kit/pull/50 from 0.1s to 50ms (Release mode), because submitting several blocks to the run loop for every single array element can be fairly inefficient.

I'd expect this to tremendously speed up template rendering as well (results forthcoming).

Example Profile result before this optimization:

<img width="1602" alt="Screen Shot 2019-04-01 at 11 06 08" src="https://user-images.githubusercontent.com/117466/55316230-3c851080-546e-11e9-9ea4-59678c56f6dd.png">

And afterwards:

<img width="1595" alt="Screen Shot 2019-04-01 at 11 06 29" src="https://user-images.githubusercontent.com/117466/55316241-4149c480-546e-11e9-925d-60751e0a8066.png">