### PR TITLE
Use NIO's `whenAll` for `Collection`.flatten now.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         /// Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "1.12.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "1.14.1"),
     ],
     targets: [
         .target(name: "Async", dependencies: ["NIO"]),

--- a/Sources/Async/Collection+Future.swift
+++ b/Sources/Async/Collection+Future.swift
@@ -1,15 +1,15 @@
-extension Collection where Element: FutureType {
+extension Collection {
     /// Maps a collection of same-type `Future`s.
     ///
     /// See `Future.map`
-    public func map<T>(to type: T.Type, on worker: Worker, _ callback: @escaping ([Element.Expectation]) throws -> T) -> Future<T> {
+    public func map<S, T>(to type: T.Type, on worker: Worker, _ callback: @escaping ([S]) throws -> T) -> Future<T> where Element == Future<S> {
         return flatten(on: worker).map(to: T.self, callback)
     }
 
     /// Maps a collection of same-type `Future`s.
     ///
     /// See `Future.flatMap`
-    public func flatMap<T>(to type: T.Type, on worker: Worker, _ callback: @escaping ([Element.Expectation]) throws -> Future<T>) -> Future<T> {
+    public func flatMap<S, T>(to type: T.Type, on worker: Worker, _ callback: @escaping ([S]) throws -> Future<T>) -> Future<T> where Element == Future<S> {
         return flatten(on: worker).flatMap(to: T.self, callback)
     }
 }

--- a/Sources/Async/Future+DoCatch.swift
+++ b/Sources/Async/Future+DoCatch.swift
@@ -48,7 +48,7 @@ extension Future {
     }
 }
 
-extension Collection where Element: FutureType {
+extension Collection {
     /// Adds a callback for handling this `[Future]`'s result when it becomes available.
     ///
     ///     futureStrings.do { strings in
@@ -58,7 +58,7 @@ extension Collection where Element: FutureType {
     ///     }
     ///
     /// - warning: Don't forget to use `catch` to handle the error case.
-    public func `do`(on worker: Worker, _ callback: @escaping ([Element.Expectation]) -> ()) -> Future<[Element.Expectation]> {
+    public func `do`<T>(on worker: Worker, _ callback: @escaping ([T]) -> ()) -> Future<[T]> where Element == Future<T> {
         return self.flatten(on: worker).do(callback)
     }
 
@@ -72,7 +72,7 @@ extension Collection where Element: FutureType {
     ///
     /// - note: Will *only* be executed if an error occurs. Successful results will not call this handler.
     @discardableResult
-    public func `catch`(on worker: Worker,_ callback: @escaping (Error) -> ()) -> Future<[Element.Expectation]> {
+    public func `catch`<T>(on worker: Worker,_ callback: @escaping (Error) -> ()) -> Future<[T]> where Element == Future<T> {
         return self.flatten(on: worker).catch(callback)
     }
 
@@ -89,7 +89,7 @@ extension Collection where Element: FutureType {
     ///
     /// - note: Will be executed on both success and failure, but will not receive any input.
     @discardableResult
-    public func always(on worker: Worker,_ callback: @escaping () -> ()) -> Future<[Element.Expectation]> {
+    public func always<T>(on worker: Worker,_ callback: @escaping () -> ()) -> Future<[T]> where Element == Future<T> {
         return self.flatten(on: worker).always(callback)
     }
 }


### PR DESCRIPTION
Benchmark results compared to Core 3.8.1:

<img width="1465" alt="Screen Shot 2019-04-11 at 11 10 40" src="https://user-images.githubusercontent.com/117466/55945120-76ae9900-5c4a-11e9-856a-d8b1d0b7fd9f.png">

I.e. another 3x improvement, as promised. (cc @weissi)

We could also delete `FutureType` entirely now. Technically, this is part of Core's public API, but as far as I can tell, its only purpose was to allow implementing `flatten`, which now seems to be possible without that workaround.