### PR TITLE
 Thread.detachNewThread available on iOS 10.0 and later.

### DIFF
--- a/Sources/Core/Thread+Async.swift
+++ b/Sources/Core/Thread+Async.swift
@@ -18,10 +18,10 @@ extension Thread {
     /// - parameters:
     ///     - work: Closure to be called on new thread.
     public static func async(_ work: @escaping () -> Void) {
-        if #available(OSX 10.12, *) {
+        if #available(macOS 10.12, iOS 10.0, *) {
             Thread.detachNewThread(work)
         } else {
-            fatalError("macOS 10.12 or later required to call Thread.async(_:)")
+            fatalError("macOS 10.12/iOS 10.0 or later required to call Thread.async(_:)")
         }
     }
 }


### PR DESCRIPTION

- Allows integrating vapor/core to iOS through SPM and Xcode 11 beta 1.  

<img width="744" alt="Screen Shot 2019-06-04 at 2 52 31 PM" src="https://user-images.githubusercontent.com/4073499/58877035-6bbb3680-86d8-11e9-90de-bf659aac82bf.png">