### PR TITLE
xcode 11 file fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Packages
 Package.pins
 Package.resolved
 DerivedData/
+.swiftpm
+

--- a/Sources/Core/DirectoryConfig.swift
+++ b/Sources/Core/DirectoryConfig.swift
@@ -21,24 +21,24 @@ public struct DirectoryConfig {
     ///
     /// - returns: The derived `DirectoryConfig` if it could be created, otherwise just "./".
     public static func detect() -> DirectoryConfig {
-        let fileBasedWorkDir: String?
+        var fileBasedWorkDir: String? = nil
 
         #if Xcode
-        // attempt to find working directory through #file
-        let file = #file
-
-        if file.contains(".build") {
-            // most dependencies are in `./.build/`
-            fileBasedWorkDir = file.components(separatedBy: "/.build").first
-        } else if file.contains("Packages") {
-            // when editing a dependency, it is in `./Packages/`
-            fileBasedWorkDir = file.components(separatedBy: "/Packages").first
-        } else {
-            // when dealing with current repository, file is in `./Sources/`
-            fileBasedWorkDir = file.components(separatedBy: "/Sources").first
+        // check if we are in Xcode via SPM integration
+        if !#file.contains("SourcePackages/checkouts") {
+            // we are NOT in Xcode via SPM integration
+            // use #file hacks to determine working directory automatically
+            if #file.contains(".build") {
+                // most dependencies are in `./.build/`
+                fileBasedWorkDir = #file.components(separatedBy: "/.build").first
+            } else if #file.contains("Packages") {
+                // when editing a dependency, it is in `./Packages/`
+                fileBasedWorkDir = #file.components(separatedBy: "/Packages").first
+            } else {
+                // when dealing with current repository, file is in `./Sources/`
+                fileBasedWorkDir = #file.components(separatedBy: "/Sources").first
+            }
         }
-        #else
-        fileBasedWorkDir = nil
         #endif
 
         let workDir: String

--- a/Tests/CoreTests/CoreTests.swift
+++ b/Tests/CoreTests/CoreTests.swift
@@ -170,6 +170,14 @@ class CoreTests: XCTestCase {
         }
     }
 
+    func testDirectoryConfig() throws {
+        let config = DirectoryConfig.detect()
+        let license = config.workDir + "LICENSE"
+        if !FileManager.default.fileExists(atPath: license) {
+            XCTFail("could not find license using directory config")
+        }
+    }
+
     static let allTests = [
         ("testProcessExecute", testProcessExecute),
         ("testProcessAsyncExecute", testProcessAsyncExecute),
@@ -179,5 +187,6 @@ class CoreTests: XCTestCase {
         ("testBase64URLEscaping", testBase64URLEscaping),
         ("testHexEncodedString", testHexEncodedString),
         ("testHeaderValue", testHeaderValue),
+        ("testDirectoryConfig", testDirectoryConfig),
     ]
 }


### PR DESCRIPTION
Swift packages fetched directly by Xcode 11 are stored in a different location than packages fetched by `swift package generate-xcodeproj`. Because of this, hacks that were previously used to automatically determine working directory no longer work in Xcode 11. 

Luckily, Xcode 11's native SPM integration allows for persistence of project settings. This was a limitation that the original auto-detection hacks were attempting to work around. Because of this, we recommend that all Vapor 3 and 4 users using Xcode 11's native SPM support set a Custom Working Directory in their `Run` scheme to the desired folder:

![Screen Shot 2019-06-11 at 4 06 33 PM](https://user-images.githubusercontent.com/1342803/59303398-2365c080-8c64-11e9-87ad-dfcb239fa99f.png)

This folder is usually the folder that contains your project's `Package.swift` file. 

---

In order for the Custom Working Directory to pass through correctly, a check has been added for a unique string that should only appear when Xcode 11's native SPM integration is being used. This should allow for Vapor 3 projects to continue working normally with `swift package generate-xcodeproj`. 

For Vapor 4, these [hacks have been removed entirely](https://github.com/vapor/vapor/commit/c3138f9a858fd61b251064f9ef3b4fb7fab07d4e), and directory config detection will always expect a Custom Working Directory to be set in the project's Run scheme. 
