### PR TITLE
Conform File to ReflectionDecodable

### DIFF
--- a/Sources/Core/CodableReflection/ReflectionDecodable.swift
+++ b/Sources/Core/CodableReflection/ReflectionDecodable.swift
@@ -125,6 +125,16 @@ extension Data: ReflectionDecodable {
     }
 }
 
+extension File: ReflectionDecodable {
+    /// See `ReflectionDecodable.reflectDecoded()` for more information.
+    public static func reflectDecoded() -> (File, File) {
+        return (
+            File(data: Data(count: 1), filename: "foo.pdf"),
+            File(data: Data(count: 2), filename: "bar.pdf")
+        )
+    }
+}
+
 extension Date: ReflectionDecodable {
     /// See `ReflectionDecodable.reflectDecoded()` for more information.
     public static func reflectDecoded() -> (Date, Date) {

--- a/Sources/Core/File.swift
+++ b/Sources/Core/File.swift
@@ -34,3 +34,11 @@ public struct File: Codable {
         self.filename = filename
     }
 }
+
+extension File: Equatable {
+    public static func ==(lhs: File, rhs: File) -> Bool {
+       return 
+        lhs.data == rhs.data && 
+        lhs.filename == rhs.filename
+    }
+}


### PR DESCRIPTION
Hi,
I tried to update the db with a migration and add a `File` property, it fails on runtime with
```
Fatal error: 'try!' expression unexpectedly raised an error: ⚠️ CoreError: File is not `ReflectionDecodable`
- id: CoreError.ReflectionDecodable
These suggestions could address the issue: 
- Conform `File` to `ReflectionDecodable`: `extension File: ReflectionDecodable { }`.
: file /.build/checkouts/fluent/Sources/Fluent/Query/FluentProperty.swift, line 14
```
Here is my fix, happy about feedback.

